### PR TITLE
Add OSX startup scripts.

### DIFF
--- a/nodes/startup/jenkins-osx-startup.plist
+++ b/nodes/startup/jenkins-osx-startup.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>jenkins-osx-startup</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>/Users/dotnet-bot/dotnet-ci/nodes/startup/jenkins-osx-startup.sh</string>
+		<string>http://dotnet-ci.cloudapp.net</string>
+		<string>dotnet-bot:<api key here></string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+        <key>KeepAlive</key>
+	<true/>
+</dict>
+</plist>

--- a/nodes/startup/jenkins-osx-startup.sh
+++ b/nodes/startup/jenkins-osx-startup.sh
@@ -1,0 +1,8 @@
+HOSTNAME=$(scutil --get LocalHostName)
+JENKINS_MASTER=$1
+JENKINS_CREDENTIALS=$2
+# Grab slave jar file
+wget $JENKINS_MASTER/jnlpJars/slave.jar -O ~/slave.jar
+# launch
+echo "java -jar ~/slave.jar -jnlpUrl $JENKINS_MASTER/computer/$HOSTNAME/slave-agent.jnlp -jnlpCredentials $JENKINS_CREDENTIALS"
+java -jar ~/slave.jar -jnlpUrl $JENKINS_MASTER/computer/$HOSTNAME/slave-agent.jnlp -jnlpCredentials $JENKINS_CREDENTIALS


### PR DESCRIPTION
To use:

    * Change plist file credentials to appropriate ones for dotnet bot (API key).
    * Change plist file to have correct path to startup script file.
    * Copy plist file to ~/Library/LaunchAgents
    * launchctl load ~/Library/LaunchAgents/jenkins-osx-startup.ps1