### PR TITLE
Fix issue where a reconnected node won't load winp

### DIFF
--- a/nodes/startup/jenkins-windows-startup.ps1
+++ b/nodes/startup/jenkins-windows-startup.ps1
@@ -7,21 +7,29 @@ Set-ExecutionPolicy Unrestricted -force
 $jenkinsserverurl = "http://dotnet-ci.cloudapp.net/"
 $vmname = $env:COMPUTERNAME
 
+# WORKAROUND - VM names are always 'Azure' and the computer name comes out as "AZURE".  Alter to avoid a 404 on the jnlp call.
 $vmname = $vmname.ToLower();
 
-# Download slave jar
+# Loop this infinitely.  The reason we do this is that in jenkins, if the master breaks the connection,
+# the slave process will wait to reconnect but will be unable to load winp.x64.dll because it will still be
+# in use by another VM instance.  Thus, if jenkins disconnects, we won't be able to kill hung processes any longer.
+# Exiting the java process (via noReconnect) should fix this, and we'll still attempt to reconnect again because
+# of the loop.
+while($true) {
+    # Download slave jar
 
-Write-Output "Downloading jenkins slave jar "
-$jarSource = $jenkinsserverurl + "jnlpJars/slave.jar"
-$jarDest = "$env:USERPROFILE\slave.jar"
-$wc = New-Object System.Net.WebClient
-$wc.DownloadFile($jarSource, $jarDest)
+    Write-Output "Downloading jenkins slave jar "
+    $jarSource = $jenkinsserverurl + "jnlpJars/slave.jar"
+    $jarDest = "$env:USERPROFILE\slave.jar"
+    $wc = New-Object System.Net.WebClient
+    $wc.DownloadFile($jarSource, $jarDest)
 
-# execute slave
-$serverURL=$jenkinsserverurl + "computer/" + $vmname + "/slave-agent.jnlp"
-# syntax for credentials username:apitoken or username:password
-# you can get api token by clicking on your username --> configure --> show api token
-$token="dotnet-bot:<insert token>"
-$commandLine="java -jar $jarDest -jnlpUrl $serverURL -jnlpCredentials $token"
-Write-Output "Executing slave process: $commandLine"
-& java -jar $jarDest -jnlpUrl $serverURL -jnlpCredentials $token
+    # execute slave
+    $serverURL=$jenkinsserverurl + "computer/" + $vmname + "/slave-agent.jnlp"
+    # syntax for credentials username:apitoken or username:password
+    # you can get api token by clicking on your username --> configure --> show api token
+    $token="dotnet-bot:<secret here>"
+    $commandLine="java -jar $jarDest -jnlpUrl $serverURL -jnlpCredentials $token -noReconnect"
+    Write-Output "Executing slave process: $commandLine"
+    & java -jar $jarDest -jnlpUrl $serverURL -jnlpCredentials $token
+}


### PR DESCRIPTION
This prevents jenkins from killing processes on Windows.