### PR TITLE
Various config updates

### DIFF
--- a/jobs/dotnet_corefx_coverage_windows/config.xml
+++ b/jobs/dotnet_corefx_coverage_windows/config.xml
@@ -104,5 +104,6 @@
       </strategy>
       <operationList/>
     </hudson.plugins.build__timeout.BuildTimeoutWrapper>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.6"/>
   </buildWrappers>
 </project>

--- a/jobs/dotnet_corefx_linux_debug_tst_prtest/config.xml
+++ b/jobs/dotnet_corefx_linux_debug_tst_prtest/config.xml
@@ -66,7 +66,7 @@
       <project>dotnet_coreclr_linux_release</project>
       <filter></filter>
       <target></target>
-      <excludes>**/testResults.xml</excludes>
+      <excludes>**/testResults.xml,**/*.ni.dll</excludes>
       <selector class="hudson.plugins.copyartifact.StatusBuildSelector"/>
       <doNotFingerprintArtifacts>false</doNotFingerprintArtifacts>
     </hudson.plugins.copyartifact.CopyArtifact>
@@ -74,7 +74,7 @@
       <project>dotnet_corefx_windows_debug_prtest</project>
       <filter></filter>
       <target></target>
-      <excludes>**/testResults.xml</excludes>
+      <excludes>**/testResults.xml,**/*.ni.dll</excludes>
       <selector class="hudson.plugins.copyartifact.ParameterizedBuildSelector">
         <parameterName>COREFX_WINDOWS_BUILD</parameterName>
       </selector>
@@ -84,7 +84,7 @@
       <project>dotnet_coreclr_windows_release</project>
       <filter>bin/Product/Linux*/**</filter>
       <target></target>
-      <excludes>**/testResults.xml</excludes>
+      <excludes>**/testResults.xml,**/*.ni.dll</excludes>
       <selector class="hudson.plugins.copyartifact.StatusBuildSelector">
         <stable>true</stable>
       </selector>
@@ -94,7 +94,7 @@
       <project>dotnet_corefx_linux_debug_prtest</project>
       <filter></filter>
       <target></target>
-      <excludes>**/testResults.xml</excludes>
+      <excludes>**/testResults.xml,**/*.ni.dll</excludes>
       <selector class="hudson.plugins.copyartifact.ParameterizedBuildSelector">
         <parameterName>COREFX_LINUX_BUILD</parameterName>
       </selector>

--- a/jobs/dotnet_corefx_windows_stress_unittests/config.xml
+++ b/jobs/dotnet_corefx_windows_stress_unittests/config.xml
@@ -16,24 +16,6 @@
     <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.11.3">
       <projectUrl>https://github.com/dotnet/corefx/</projectUrl>
     </com.coravy.hudson.plugins.github.GithubProjectProperty>
-    <hudson.model.ParametersDefinitionProperty>
-      <parameterDefinitions>
-        <hudson.plugins.copyartifact.BuildSelectorParameter plugin="copyartifact@1.35.1">
-          <name>COREFX_LINUX_BUILD</name>
-          <description></description>
-          <defaultSelector class="hudson.plugins.copyartifact.SpecificBuildSelector">
-            <buildNumber></buildNumber>
-          </defaultSelector>
-        </hudson.plugins.copyartifact.BuildSelectorParameter>
-        <hudson.plugins.copyartifact.BuildSelectorParameter plugin="copyartifact@1.35.1">
-          <name>COREFX_WINDOWS_BUILD</name>
-          <description></description>
-          <defaultSelector class="hudson.plugins.copyartifact.SpecificBuildSelector">
-            <buildNumber></buildNumber>
-          </defaultSelector>
-        </hudson.plugins.copyartifact.BuildSelectorParameter>
-      </parameterDefinitions>
-    </hudson.model.ParametersDefinitionProperty>
   </properties>
   <scm class="hudson.plugins.git.GitSCM" plugin="git@2.3.5">
     <configVersion>2</configVersion>
@@ -53,67 +35,45 @@
       <hudson.plugins.git.extensions.impl.WipeWorkspace/>
     </extensions>
   </scm>
-  <assignedNode>ubuntu</assignedNode>
+  <assignedNode>windows</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-  <triggers/>
+  <triggers>
+    <hudson.triggers.TimerTrigger>
+      <spec>@daily</spec>
+    </hudson.triggers.TimerTrigger>
+  </triggers>
   <concurrentBuild>true</concurrentBuild>
   <builders>
-    <hudson.plugins.copyartifact.CopyArtifact plugin="copyartifact@1.35.1">
-      <project>dotnet_coreclr_linux_release</project>
-      <filter></filter>
-      <target></target>
-      <excludes>**/testResults.xml,**/*.ni.dll</excludes>
-      <selector class="hudson.plugins.copyartifact.StatusBuildSelector"/>
-      <doNotFingerprintArtifacts>false</doNotFingerprintArtifacts>
-    </hudson.plugins.copyartifact.CopyArtifact>
-    <hudson.plugins.copyartifact.CopyArtifact plugin="copyartifact@1.35.1">
-      <project>dotnet_corefx_windows_debug</project>
-      <filter></filter>
-      <target></target>
-      <excludes>**/testResults.xml,**/*.ni.dll</excludes>
-      <selector class="hudson.plugins.copyartifact.ParameterizedBuildSelector">
-        <parameterName>COREFX_WINDOWS_BUILD</parameterName>
-      </selector>
-      <doNotFingerprintArtifacts>false</doNotFingerprintArtifacts>
-    </hudson.plugins.copyartifact.CopyArtifact>
-    <hudson.plugins.copyartifact.CopyArtifact plugin="copyartifact@1.35.1">
-      <project>dotnet_coreclr_windows_release</project>
-      <filter>bin/Product/Linux*/**</filter>
-      <target></target>
-      <excludes>**/testResults.xml,**/*.ni.dll</excludes>
-      <selector class="hudson.plugins.copyartifact.StatusBuildSelector">
-        <stable>true</stable>
-      </selector>
-      <doNotFingerprintArtifacts>false</doNotFingerprintArtifacts>
-    </hudson.plugins.copyartifact.CopyArtifact>
-    <hudson.plugins.copyartifact.CopyArtifact plugin="copyartifact@1.35.1">
-      <project>dotnet_corefx_linux_debug</project>
-      <filter></filter>
-      <target></target>
-      <excludes>**/testResults.xml,**/*.ni.dll</excludes>
-      <selector class="hudson.plugins.copyartifact.ParameterizedBuildSelector">
-        <parameterName>COREFX_LINUX_BUILD</parameterName>
-      </selector>
-      <doNotFingerprintArtifacts>false</doNotFingerprintArtifacts>
-    </hudson.plugins.copyartifact.CopyArtifact>
-    <hudson.tasks.Shell>
-      <command>./run-test.sh --configuration Debug --os Linux --coreclr-bins ${WORKSPACE}/bin/Product/Linux.x64.Release/ --mscorlib-bins ${WORKSPACE}/bin/Product/Linux.x64.Release/
-# Always exit with 0.  Expected to fail right now
-exit 0</command>
-    </hudson.tasks.Shell>
+    <hudson.tasks.BatchFile>
+      <command>&quot;C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat&quot; x86 &amp;&amp; build.cmd /p:OSGroup=Windows_NT /p:Configuration=Debug /p:XunitOptions=&quot;-maxthreads 100&quot;</command>
+    </hudson.tasks.BatchFile>
   </builders>
   <publishers>
+    <com.microsoftopentechnologies.windowsazurestorage.WAStoragePublisher plugin="windows-azure-storage@0.3.1-SNAPSHOT">
+      <storageAccName>dotnetci</storageAccName>
+      <containerName>dotnet-corefx-windows-debug</containerName>
+      <cntPubAccess>true</cntPubAccess>
+      <cleanUpContainer>true</cleanUpContainer>
+      <allowAnonymousAccess>true</allowAnonymousAccess>
+      <uploadArtifactsOnlyIfSuccessful>false</uploadArtifactsOnlyIfSuccessful>
+      <doNotFailIfArchivingReturnsNothing>true</doNotFailIfArchivingReturnsNothing>
+      <uploadZips>false</uploadZips>
+      <doNotUploadIndividualFiles>false</doNotUploadIndividualFiles>
+      <filesPath>bin/**,msbuild.log</filesPath>
+      <excludeFilesPath>bin/obj/**,bin/packages/**,bin/**/*.Tests/*,bin/**/System.Threading.Tasks.Dataflow.WP8/*,bin/**/System.Reflection.Metadata/System.Collections.Immutable.*,**/api-*,**/API-*</excludeFilesPath>
+      <virtualPath>${BUILD_NUMBER}</virtualPath>
+    </com.microsoftopentechnologies.windowsazurestorage.WAStoragePublisher>
     <xunit plugin="xunit@1.95">
       <types>
         <XUnitDotNetTestType>
-          <pattern>**/testResults.xml</pattern>
+          <pattern>bin/tests/**/testResults.xml</pattern>
           <skipNoTestFiles>true</skipNoTestFiles>
           <failIfNotNew>false</failIfNotNew>
           <deleteOutputFiles>true</deleteOutputFiles>
-          <stopProcessingIfError>false</stopProcessingIfError>
+          <stopProcessingIfError>true</stopProcessingIfError>
         </XUnitDotNetTestType>
       </types>
       <thresholds>

--- a/jobs/dotnet_llilc/config.xml
+++ b/jobs/dotnet_llilc/config.xml
@@ -55,7 +55,7 @@
   <buildWrappers/>
   <icon/>
   <dsl>parallel (
-    { build(&quot;dotnet_llilc_debug_win64&quot;) },
+    { build(&quot;dotnet_llilc_check_win64&quot;) },
     { build(&quot;dotnet_llilc_release_win64&quot;) },
     { build(&quot;dotnet_llilc_debug_win32&quot;) },
     { build(&quot;dotnet_llilc_release_win32&quot;) },

--- a/jobs/dotnet_llilc_debug_win64/config.xml
+++ b/jobs/dotnet_llilc_debug_win64/config.xml
@@ -97,7 +97,11 @@
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-  <triggers/>
+  <triggers>
+    <hudson.triggers.TimerTrigger>
+      <spec>H H * * 6</spec>
+    </hudson.triggers.TimerTrigger>
+  </triggers>
   <concurrentBuild>true</concurrentBuild>
   <builders>
     <com.microsoftopentechnologies.windowsazurestorage.AzureStorageBuilder plugin="windows-azure-storage@0.3.1-SNAPSHOT">
@@ -124,38 +128,21 @@ cd coreclr&#xd;
 cmake -G &quot;Visual Studio 12 2013 Win64&quot; -DWITH_CORECLR=%WORKSPACE%\coreclr\bin\Product\Windows_NT.x64.debug ..\llvm&#xd;
 &quot;%VS120COMNTOOLS%\..\..\VC\vcvarsall.bat&quot; x86 &amp;&amp; msbuild llvm.sln /p:Configuration=Debug /p:Platform=x64 /t:ALL_BUILD /m</command>
     </hudson.tasks.BatchFile>
-    <hudson.plugins.powershell.PowerShell plugin="powershell@1.2">
-      <command>$env:LLVMSource = $env:WORKSPACE + &quot;\LLVM\&quot;
-$env:LLVMBuild = $env:WORKSPACE + &quot;\build\&quot;
-$env:LLILCTestResult = $env:WORKSPACE + &quot;\test\&quot;
-$env:CoreCLRSource=$env:WORKSPACE + &quot;\coreclr&quot;
-$env:Path = ($env:Path).Replace(&quot;`&quot;&quot;,&quot;&quot;) + &quot;;C:\Python34;C:\GnuWin32\bin&quot;
-
-&amp; $Env:LLVMSOURCE\tools\llilc\test\LLILCEnv.ps1 -Build Debug -Arch x64
-BuildTest -Arch x64 -Build Debug
-CopyJit
-
-Write-Output &quot;Running: RunTest -Arch x64 -Build Debug -Jit $env:WORKSPACE\lkg\llilcjit.dll -Result SummaryBase -Dump Summary&quot;
-$failures = RunTest -Arch x64 -Build Debug -Jit $env:WORKSPACE\lkg\llilcjit.dll -Result SummaryBase -Dump Summary
-
-if (-Not ($failures)) {
-Write-Output &quot;There were failures with the baseline Jit&quot;
-}
-
-Write-Output &quot;Running: RunTest -Arch x64 -Build Debug -Result SummaryDiff -Dump Summary&quot;
-$failures = RunTest -Arch x64 -Build Debug -Result SummaryDiff -Dump Summary
-
-if (-Not ($failures)) {
-throw &quot;There were failures with the new Jit&quot;
-}
-
-Write-Output &quot;Running: CheckDiff -Base SummaryBase -Diff SummaryDiff -Summary&quot;
-$diffs = CheckDiff -Base SummaryBase -Diff SummaryDiff -Summary
-
-if (-Not ($diffs -eq 0)) {
-throw &quot;There were diffs.&quot;
-}</command>
-    </hudson.plugins.powershell.PowerShell>
+    <hudson.tasks.BatchFile>
+      <command>if exist baseline/ rd /s /q baseline/&#xd;
+mkdir baseline&#xd;
+if exist target/ rd /s /q target/&#xd;
+mkdir target&#xd;
+&#xd;
+cd coreclr\tests&#xd;
+&#xd;
+C:\Python34\python %WORKSPACE%\llvm\tools\llilc\test\llilc_runtest.py -a x64 -b debug -d summary -r ..\..\baseline -j %WORKSPACE%\lkg\llilcjit.dll -c %WORKSPACE%\coreclr\bin\Product\Windows_NT.x64.Debug&#xd;
+&#xd;
+C:\Python34\python %WORKSPACE%\llvm\tools\llilc\test\llilc_runtest.py -a x64 -b debug -d summary -r ..\..\target -j %WORKSPACE%\build\bin\Debug\llilcjit.dll -c %WORKSPACE%\coreclr\bin\Product\Windows_NT.x64.Debug || (echo There were failures with the new JIT&amp; exit /b -1)&#xd;
+&#xd;
+C:\Python34\python %WORKSPACE%\llvm\tools\llilc\test\llilc_checkpass.py -b ..\..\baseline -d ..\..\target || (echo There were diffs.&amp; exit /b -1)&#xd;
+</command>
+    </hudson.tasks.BatchFile>
   </builders>
   <publishers>
     <xunit plugin="xunit@1.95">
@@ -205,7 +192,7 @@ throw &quot;There were diffs.&quot;
   <buildWrappers>
     <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@1.14.1">
       <strategy class="hudson.plugins.build_timeout.impl.AbsoluteTimeOutStrategy">
-        <timeoutMinutes>240</timeoutMinutes>
+        <timeoutMinutes>480</timeoutMinutes>
       </strategy>
       <operationList/>
     </hudson.plugins.build__timeout.BuildTimeoutWrapper>

--- a/jobs/dotnet_llilc_release_win64/config.xml
+++ b/jobs/dotnet_llilc_release_win64/config.xml
@@ -125,44 +125,21 @@ cd coreclr&#xd;
 cmake -G &quot;Visual Studio 12 2013 Win64&quot; -DWITH_CORECLR=%WORKSPACE%\coreclr\bin\Product\Windows_NT.x64.Release ..\llvm&#xd;
 &quot;%VS120COMNTOOLS%\..\..\VC\vcvarsall.bat&quot; x86 &amp;&amp; msbuild llvm.sln /p:Configuration=Release /p:Platform=x64 /t:ALL_BUILD /m</command>
     </hudson.tasks.BatchFile>
-    <hudson.plugins.powershell.PowerShell plugin="powershell@1.2">
-      <command>$env:LLVMSource = $env:WORKSPACE + &quot;\LLVM\&quot;
-$env:LLVMBuild = $env:WORKSPACE + &quot;\build\&quot;
-$env:LLILCTestResult = $env:WORKSPACE + &quot;\test\&quot;
-$env:CoreCLRSource=$env:WORKSPACE + &quot;\coreclr&quot;
-$env:Path = ($env:Path).Replace(&quot;`&quot;&quot;,&quot;&quot;) + &quot;;C:\Python34;C:\GnuWin32\bin&quot;
-$TestBase = $True
-
-&amp; $Env:LLVMSOURCE\tools\llilc\test\LLILCEnv.ps1 -Build Release -Arch x64
-BuildTest -Arch x64 -Build Release
-CopyJit -Build Release
-
-if($TestBase) {
-Write-Output &quot;Running: RunTest -Arch x64 -Build Release -Jit $env:WORKSPACE\lkg\llilcjit.dll -Result SummaryBase -Dump Summary&quot;
-$failures = RunTest -Arch x64 -Build Release -Jit $env:WORKSPACE\lkg\llilcjit.dll -Result SummaryBase -Dump Summary
-
-if (-Not ($failures)) {
-Write-Output&quot;There were failures with the baseline Jit&quot;
-}
-}
-
-Write-Output &quot;Running: RunTest -Arch x64 -Build Release -Result SummaryDiff -Dump Summary&quot;
-$failures = RunTest -Arch x64 -Build Release -Result SummaryDiff -Dump Summary
-
-if (-Not ($failures)) {
-throw &quot;There were $failures failures with the new Jit&quot;
-}
-
-if($TestBase) {
-Write-Output &quot;Running: CheckDiff -Base SummaryBase -Diff SummaryDiff -Summary&quot;
-$diffs = CheckDiff -Base SummaryBase -Diff SummaryDiff -Summary
-
-if (-Not ($diffs -eq 0)) {
-throw &quot;There were diffs.&quot;
-}
-
-}</command>
-    </hudson.plugins.powershell.PowerShell>
+    <hudson.tasks.BatchFile>
+      <command>if exist baseline/ rd /s /q baseline/&#xd;
+mkdir baseline&#xd;
+if exist target/ rd /s /q target/&#xd;
+mkdir target&#xd;
+&#xd;
+cd coreclr\tests&#xd;
+&#xd;
+C:\Python34\python %WORKSPACE%\llvm\tools\llilc\test\llilc_runtest.py -a x64 -b release -d summary -r ..\..\baseline -j %WORKSPACE%\lkg\llilcjit.dll -c %WORKSPACE%\coreclr\bin\Product\Windows_NT.x64.Release&#xd;
+&#xd;
+C:\Python34\python %WORKSPACE%\llvm\tools\llilc\test\llilc_runtest.py -a x64 -b release -d summary -r ..\..\target -j %WORKSPACE%\build\bin\Release\llilcjit.dll -c %WORKSPACE%\coreclr\bin\Product\Windows_NT.x64.Release || (echo There were failures with the new JIT&amp; exit /b -1)&#xd;
+&#xd;
+C:\Python34\python %WORKSPACE%\llvm\tools\llilc\test\llilc_checkpass.py -b ..\..\baseline -d ..\..\target || (echo There were diffs.&amp; exit /b -1)&#xd;
+</command>
+    </hudson.tasks.BatchFile>
   </builders>
   <publishers>
     <xunit plugin="xunit@1.95">

--- a/jobs/dotnet_wcf_outerloop/config.xml
+++ b/jobs/dotnet_wcf_outerloop/config.xml
@@ -26,7 +26,7 @@
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>*/scenario</name>
+        <name>*/master</name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>


### PR DESCRIPTION
* Add unittest stress config
* Avoid copying .ni.dll for Linux builds.  mscorlib.ni.dll is the windows cross-genned version and causes problems.
* llilc change scripting to python