### PR TITLE
Build FreeBSD mscorlib on Windows

### DIFF
--- a/jobs/dotnet_coreclr_windows_debug/config.xml
+++ b/jobs/dotnet_coreclr_windows_debug/config.xml
@@ -44,7 +44,7 @@
   <concurrentBuild>true</concurrentBuild>
   <builders>
     <hudson.tasks.BatchFile>
-      <command>build.cmd Debug &amp;&amp; tests\runtest.cmd Debug &amp;&amp; build.cmd linuxmscorlib &amp;&amp; build.cmd osxmscorlib</command>
+      <command>build.cmd Debug &amp;&amp; tests\runtest.cmd Debug &amp;&amp; build.cmd linuxmscorlib &amp;&amp; build.cmd freebsdmscorlib &amp;&amp; build.cmd osxmscorlib</command>
     </hudson.tasks.BatchFile>
   </builders>
   <publishers>

--- a/jobs/dotnet_coreclr_windows_debug_prtest/config.xml
+++ b/jobs/dotnet_coreclr_windows_debug_prtest/config.xml
@@ -45,7 +45,7 @@
   <concurrentBuild>true</concurrentBuild>
   <builders>
     <hudson.tasks.BatchFile>
-      <command>build.cmd Debug &amp;&amp; tests\runtest.cmd Debug &amp;&amp; build.cmd linuxmscorlib &amp;&amp; build.cmd osxmscorlib</command>
+      <command>build.cmd Debug &amp;&amp; tests\runtest.cmd Debug &amp;&amp; build.cmd linuxmscorlib &amp;&amp; build.cmd freebsdmscorlib &amp;&amp; build.cmd osxmscorlib</command>
     </hudson.tasks.BatchFile>
   </builders>
   <publishers>

--- a/jobs/dotnet_coreclr_windows_release/config.xml
+++ b/jobs/dotnet_coreclr_windows_release/config.xml
@@ -44,7 +44,7 @@
   <concurrentBuild>true</concurrentBuild>
   <builders>
     <hudson.tasks.BatchFile>
-      <command>build.cmd Release &amp;&amp; tests\runtest.cmd Release &amp;&amp; build.cmd linuxmscorlib Release &amp;&amp; build.cmd osxmscorlib Release</command>
+      <command>build.cmd Release &amp;&amp; tests\runtest.cmd Release &amp;&amp; build.cmd linuxmscorlib Release &amp;&amp; build.cmd freebsdmscorlib Release &amp;&amp; build.cmd osxmscorlib Release</command>
     </hudson.tasks.BatchFile>
   </builders>
   <publishers>

--- a/jobs/dotnet_coreclr_windows_release_prtest/config.xml
+++ b/jobs/dotnet_coreclr_windows_release_prtest/config.xml
@@ -45,7 +45,7 @@
   <concurrentBuild>true</concurrentBuild>
   <builders>
     <hudson.tasks.BatchFile>
-      <command>build.cmd Release &amp;&amp; tests\runtest.cmd Release &amp;&amp; build.cmd linuxmscorlib Release &amp;&amp; build.cmd osxmscorlib Release</command>
+      <command>build.cmd Release &amp;&amp; tests\runtest.cmd Release &amp;&amp; build.cmd linuxmscorlib Release &amp;&amp; build.cmd freebsdmscorlib Release &amp;&amp; build.cmd osxmscorlib Release</command>
     </hudson.tasks.BatchFile>
   </builders>
   <publishers>


### PR DESCRIPTION
Once https://github.com/dotnet/coreclr/pull/1116
gets merged, start building FreeBSD mscorlib as well.