### PR TITLE
Enable auto-reimage

### DIFF
--- a/ci-nodes/management/Capture-Image.ps1
+++ b/ci-nodes/management/Capture-Image.ps1
@@ -67,6 +67,18 @@ elseif ($Machine -match "fbsd")
 	$osType = "fbsd"
 	$osDescription = "FreeBSD 10.1"
 }
+elseif ($Machine -match "cnt71")
+{
+	# Centos 7.1
+	$osType = "cnt71"
+	$osDescription = "Centos 7.1"
+}
+elseif ($Machine -match "s132")
+{
+	# OpenSUSE 13.2
+	$osType = "s132"
+	$osDescription = "OpenSUSE 13.2"
+}
 else
 {
 	throw "Unknown OS type.  Expected $Machine to contain 'win, ub, or fbsd'"

--- a/ci-nodes/management/Cycle-Nodes.ps1
+++ b/ci-nodes/management/Cycle-Nodes.ps1
@@ -11,6 +11,17 @@
     New image to place on those machines
 .PARAMETER AllowMissingMachines
     If machines are not currently in azure, allows creation
+.PARAMETER Auto
+    Automatic cycling of nodes.  Connects to Jenkins through the CLI to take machines offline, wait for idle, and then cycle
+    the machine to the new image.
+.PARAMETER DryRun
+    Make no changes, dry run only
+.PARAMETER IdleWait
+    If Auto is on, number of minutes to wait before checking whether a machine is idle
+.PARAMETER MaxIdleTimes
+    Maximum number of wait tries before aborting an image update for a busy machine.
+.PARAMETER PrivateKey
+    Private SSH key required for automatic image update
 .PARAMETER Verbose
     Verbose tracing of the script
 #>
@@ -18,13 +29,21 @@
 param (
     [string]$Password = $(Read-Host -assecurestring -prompt "Password for user"),
     [string]$Machines = $(Read-Host -prompt "Regex pattern for machines to cycle"),
-    [string]$NewImage = $null,
+    [string]$NewImage = $(Read-Host -prompt "New image to cycle machines to."),
+    [switch]$Auto = $false,
+    [switch]$DryRun = $false,
+    [string]$PrivateKey = $null,
+	[int]$IdleWait = 10,
+	[int]$MaxIdleTimes = 24,
     [switch]$AllowMissingMachines = $false,
     [switch]$Verbose = $false
 )
 
 $ServiceName="dotnet-ci-nodes"
 $Username="dotnet-bot"
+$JenkinsInstance="http://dotnet-ci.cloudapp.net"
+$JenkinsCLIJarURL="$JenkinsInstance/jnlpJars/jenkins-cli.jar"
+$JenkinsCLIJar="$env:TEMP\jenkins-cli.jar"
 
 Write-Host "Reading inventory from inventory.txt"
 
@@ -32,8 +51,9 @@ Write-Host "Reading inventory from inventory.txt"
 
 $inventory = Get-Content inventory.txt | ConvertFrom-Csv
 
-# Walk the machines, append the current count and check against the regex provided.  If it matches,
-# then cycle the machine to the new image.
+# Make a list of the machines that need to get updates.
+
+$machinesThatNeedUpdates = @()
 
 foreach ($machine in $inventory)
 {
@@ -48,97 +68,218 @@ foreach ($machine in $inventory)
         
         if ($fullMachineName -match $Machines)
         {
-            if ($Verbose)
-            {
-                Write-Host "Matched"
-            }
-            
-            $imageToUse = $NewImage
-
-            if ($imageToUse -eq $null)
-            {
-                $imageToUse = $NewImage
-            }
-
-            # Check to see whether the new vm image actually exists
-
-            $newImageCheck = Get-AzureVMImage $imageToUse
-
-            if (!$newImageCheck)
-            {
-                throw "VM $imageToUse did not exist, aborting"
-            }
-
-            [int]$port = [int]$machine.RdpSshStart;
-            $port += $i
-            
-            Write-Host "Cycling $fullMachineName to $NewImage with RDP/SSH on $port"
-
-            # Check for existence of the old machine
-
-            $existingVM = Get-AzureVM -ServiceName $ServiceName -Name $fullMachineName
-
-            if (-not $existingVM)
-            {
-                if ($AllowMissingMachines)
-                {
-                    Write-Warning "VM $fullMachineName did not exist...creating"
-                }
-                else
-                {
-                    throw "VM $fullMachineName did not exist."
-                }
-            }
-            else
-            {
-                # Delete the old machine
-            
-                Remove-AzureVM -ServiceName $ServiceName -Name $fullMachineName -DeleteVHD
-            }
-                    
-            switch ($machine.OSType)
-            {
-                "Windows"
-                {
-                    # Create the new one
-
-                    $newVM = New-AzureQuickVM -Windows -ServiceName $ServiceName -Name $fullMachineName -ImageName $imageToUse -AdminUsername $Username -Password $Password -InstanceSize $machine.Size
-                    
-                    if (!$newVM)
-                    {
-                        throw "Could not create $fullMachineName"
-                    }
-                    
-                    Get-AzureVM -ServiceName $ServiceName -Name $fullMachineName | Set-AzureEndpoint -Name "RemoteDesktop" -PublicPort $port -LocalPort 3389 -Protocol TCP | Update-AzureVM
-					
-					Write-Host "Remember, mstsc /v:dotnet-ci-nodes.cloudapp.net:$port in a few minutes to start the jenkins process"
-                }
-                "Linux"
-                {
-                    $newVM = New-AzureQuickVM -Linux -ServiceName $ServiceName -Name $fullMachineName -ImageName $imageToUse -LinuxUser $Username -Password $Password -InstanceSize $machine.Size
-                    
-                    if (!$newVM)
-                    {
-                        throw "Could not create $fullMachineName"
-                    }
-                    
-                    # Alter the endpoint so that the SSH port is predictable
-                    
-                    Get-AzureVM -ServiceName $ServiceName -Name $fullMachineName | Set-AzureEndpoint -Name "SSH" -PublicPort $port -LocalPort 22 -Protocol TCP | Update-AzureVM
-                }
-                default
-                {
-                    throw "Unknown OS type $machine.OSType"
-                }
-            }
+			Write-Host "Matched"
+			
+            $machinesThatNeedUpdates += @{
+				FullMachineName = $fullMachineName;
+				Port = [int]$machine.RdpSshStart + [int]$i;
+				OSType = $machine.OSType;
+				Cycled = $false;
+                Size = $machine.Size
+				}
         }
-        else
+		else {
+			Write-Host "Not Matched"
+		}
+    }
+}
+            
+if ($Verbose) {
+    Write-Host "The following machines will be updated: "
+    foreach($entry in $machinesThatNeedUpdates) {
+		$entry.GetEnumerator() | Sort-Object Name
+		Write-Host
+	}
+}
+
+# Check to see whether the new vm image actually exists
+
+$newImageCheck = Get-AzureVMImage $NewImage
+
+if (!$newImageCheck)
+{
+	throw "VM $NewImage did not exist, aborting"
+}
+
+# 1. Walk the machine update list and set everything offline.
+# 2. Walk the machine update list and check if idle.  If machine is idle, cycle and set online
+# 3. At end of loop, if not all machines were updated, wait $IdleWait mins and restart go back to 2.
+# 4. If not all machines updated after MaxIdleWaits, set all machines back online.
+
+if ($Auto)
+{
+    # Download Jar to temp
+	WGet $JenkinsCLIJarURL -OutFile $JenkinsCLIJar
+    
+    if (!$DryRun) {
+        Write-Host "Taking machines offline for auto-update"
+        
+        foreach ($machine in $machinesThatNeedUpdates)
         {
-            if ($Verbose)
+            $fullMachineName = $machine.FullMachineName
+            & java -jar $JenkinsCLIJar -i $PrivateKey -s $JenkinsInstance offline-node $fullMachineName -m "Taking offline for automated image update"
+            
+            if (-not $?)
             {
-                Write-Host "Not Matched"
+                throw "Failed to take $fullMachineName offline"
             }
         }
     }
 }
 
+$waitsLeft = $MaxIdleTimes
+$notAllUpdated = $false
+
+do
+{
+	$notAllUpdated = $false
+	
+    foreach ($machine in $machinesThatNeedUpdates)
+    {
+		# If already updated, skip
+		
+		if ($machine.Cycled)
+		{
+			continue
+		}
+        
+        $fullMachineName = $machine.FullMachineName
+        $port = $machine.Port
+		
+		# If in auto-mode, check to see whether the machine is quiet now
+		
+		if ($Auto)
+		{
+            Write-Output "Checking status of $fullMachineName"
+            
+			$idleOutput = & java -jar $JenkinsCLIJar -i $PrivateKey -s $JenkinsInstance groovy check-is-idle.groovy $fullMachineName
+			if ($idleOutput -contains "Busy")
+			{
+                Write-Host "$fullMachineName is Busy, waiting till later"
+				# Machine is busy.
+				$notAllUpdated = $true
+				continue
+			}
+			elseif ($idleOutput -contains "Idle")
+			{
+				# Ready to go.
+				if ($Verbose)
+				{
+					Write-Host "$fullMachineName is Idle and ready to be cycled"
+				}
+			}
+			else
+			{
+				# Unknown response from the script
+				throw "Unknown response '$idleOutput' from check-is-idle.groovy script"
+			}
+		}
+		
+        Write-Host "Cycling $fullMachineName to $NewImage with RDP/SSH on $port"
+        
+        if ($DryRun) {
+            # Dry run, mark as cycled and continue
+            $machine.Cycled = $true
+            continue;
+        }
+		
+        # Check for existence of the old machine
+
+        $existingVM = Get-AzureVM -ServiceName $ServiceName -Name $fullMachineName
+
+        if (-not $existingVM)
+        {
+            if ($AllowMissingMachines)
+            {
+                Write-Warning "VM $fullMachineName did not exist...creating"
+            }
+            else
+            {
+                throw "VM $fullMachineName did not exist."
+            }
+        }
+        else
+        {
+            # Delete the old machine
+        
+            Remove-AzureVM -ServiceName $ServiceName -Name $fullMachineName -DeleteVHD
+        }
+        
+        $machineSize = $machine.Size
+        $osType = $machine.OSType
+        
+        switch ($osType)
+        {
+            "Windows"
+            {
+                # Create the new one
+
+                $newVM = New-AzureQuickVM -Windows -ServiceName $ServiceName -Name $fullMachineName -ImageName $NewImage -AdminUsername $Username -Password $Password -InstanceSize $machineSize
+                
+                if (!$newVM)
+                {
+                    throw "Could not create $fullMachineName"
+                }
+                
+                Get-AzureVM -ServiceName $ServiceName -Name $fullMachineName | Set-AzureEndpoint -Name "RemoteDesktop" -PublicPort $port -LocalPort 3389 -Protocol TCP | Update-AzureVM
+                
+                Write-Host "Remember, mstsc /v:dotnet-ci-nodes.cloudapp.net:$port in a few minutes to start the jenkins process"
+            }
+            "Linux"
+            {
+                $newVM = New-AzureQuickVM -Linux -ServiceName $ServiceName -Name $fullMachineName -ImageName $NewImage -LinuxUser $Username -Password $Password -InstanceSize $machineSize
+                
+                if (!$newVM)
+                {
+                    throw "Could not create $fullMachineName"
+                }
+                
+                # Alter the endpoint so that the SSH port is predictable
+                
+                Get-AzureVM -ServiceName $ServiceName -Name $fullMachineName | Set-AzureEndpoint -Name "SSH" -PublicPort $port -LocalPort 22 -Protocol TCP | Update-AzureVM
+            }
+            default
+            {
+                throw "Unknown OS type $osType"
+            }
+        }
+		
+		# Done cycling.  Set the machine online if in auto mode
+		
+		if ($Auto)
+		{
+			& java -jar $JenkinsCLIJar -i $PrivateKey -s $JenkinsInstance online-node $fullMachineName
+		
+			if (-not $?)
+			{
+				throw "Failed to take $fullMachineName online"
+			}
+		}
+    }
+	
+	# If in auto mode and we haven't updated everything, wait the idle time mins
+	
+	if ($Auto -and $notAllUpdated)
+	{
+		if ($waitsLeft -eq 0)
+		{
+			# Print those machines that haven't been updated
+			
+			foreach ($entry in $machinesThatNeedUpdates)
+			{
+				if ($entry.Cycled)
+				{
+					continue
+				}
+				
+				$entry.GetEnumerator() | Sort-Object Name
+				Write-Host
+			}
+			throw "Failed to update all machines, some left."
+		}
+		
+		$waitsLeft--
+		Sleep $($IdleWait * 60)
+	}
+}
+while ($notAllUpdated)

--- a/ci-nodes/management/check-is-idle.groovy
+++ b/ci-nodes/management/check-is-idle.groovy
@@ -1,0 +1,13 @@
+import hudson.model.*
+
+println "Checking status of node: " + args[0];
+
+def node = Hudson.getInstance().getNode(args[0]);
+
+if (node == null) {
+    println("Node not found!");
+} else if (node.getComputer().isIdle()) {
+    println("Idle");
+} else {
+    println("Busy");
+}


### PR DESCRIPTION
Auto reimage allows the system to automatically take machines in the pool offline for updates, rather than having to manually determine when machines are ready