### PR TITLE
Update corefx_*_nativecom_* job descriptions to use merged build.sh

### DIFF
--- a/jobs/dotnet_corefx_linux_centos71_nativecomp_debug/config.xml
+++ b/jobs/dotnet_corefx_linux_centos71_nativecomp_debug/config.xml
@@ -68,7 +68,7 @@
   <concurrentBuild>true</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>./src/Native/build.sh x64 debug</command>
+      <command>./build.sh native x64 debug</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/dotnet_corefx_linux_centos71_nativecomp_release/config.xml
+++ b/jobs/dotnet_corefx_linux_centos71_nativecomp_release/config.xml
@@ -68,7 +68,7 @@
   <concurrentBuild>true</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>./src/Native/build.sh x64 release</command>
+      <command>./build.sh native x64 release</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/dotnet_corefx_linux_nativecomp_debug/config.xml
+++ b/jobs/dotnet_corefx_linux_nativecomp_debug/config.xml
@@ -44,7 +44,7 @@
   <concurrentBuild>true</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>./src/Native/build.sh x64 debug</command>
+      <command>./build.sh native x64 debug</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/dotnet_corefx_linux_nativecomp_debug_prtest/config.xml
+++ b/jobs/dotnet_corefx_linux_nativecomp_debug_prtest/config.xml
@@ -74,7 +74,7 @@
   <concurrentBuild>true</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>./src/Native/build.sh x64 debug</command>
+      <command>./build.sh native x64 debug</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/dotnet_corefx_linux_nativecomp_release/config.xml
+++ b/jobs/dotnet_corefx_linux_nativecomp_release/config.xml
@@ -44,7 +44,7 @@
   <concurrentBuild>true</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>./src/Native/build.sh x64 release</command>
+      <command>./build.sh native x64 release</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/dotnet_corefx_linux_nativecomp_release_prtest/config.xml
+++ b/jobs/dotnet_corefx_linux_nativecomp_release_prtest/config.xml
@@ -74,7 +74,7 @@
   <concurrentBuild>true</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>./src/Native/build.sh x64 release</command>
+      <command>./build.sh native x64 release</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/dotnet_corefx_linux_opensuse132_nativecomp_debug/config.xml
+++ b/jobs/dotnet_corefx_linux_opensuse132_nativecomp_debug/config.xml
@@ -68,7 +68,7 @@
   <concurrentBuild>true</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>./src/Native/build.sh x64 debug</command>
+      <command>./build.sh native x64 debug</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/dotnet_corefx_linux_opensuse132_nativecomp_release/config.xml
+++ b/jobs/dotnet_corefx_linux_opensuse132_nativecomp_release/config.xml
@@ -68,7 +68,7 @@
   <concurrentBuild>true</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>./src/Native/build.sh x64 release</command>
+      <command>./build.sh native x64 release</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/dotnet_corefx_mac_nativecomp_debug/config.xml
+++ b/jobs/dotnet_corefx_mac_nativecomp_debug/config.xml
@@ -48,7 +48,7 @@
   <concurrentBuild>true</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>./src/Native/build.sh x64 debug</command>
+      <command>./build.sh native x64 debug</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/dotnet_corefx_mac_nativecomp_debug_prtest/config.xml
+++ b/jobs/dotnet_corefx_mac_nativecomp_debug_prtest/config.xml
@@ -74,7 +74,7 @@
   <concurrentBuild>true</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>./src/Native/build.sh x64 debug</command>
+      <command>./build.sh native x64 debug</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/dotnet_corefx_mac_nativecomp_release/config.xml
+++ b/jobs/dotnet_corefx_mac_nativecomp_release/config.xml
@@ -48,7 +48,7 @@
   <concurrentBuild>true</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>./src/Native/build.sh x64 release</command>
+      <command>./build.sh native x64 release</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/dotnet_corefx_mac_nativecomp_release_prtest/config.xml
+++ b/jobs/dotnet_corefx_mac_nativecomp_release_prtest/config.xml
@@ -74,7 +74,7 @@
   <concurrentBuild>true</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>./src/Native/build.sh x64 release</command>
+      <command>./build.sh native x64 release</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>


### PR DESCRIPTION
dotnet/corefx#3175 proposes to merge the existing src/Native/build.sh
into the top level build.sh, breaking the PR builds. This commit changes
the job descriptions to use the merged top level build.sh.