### PR TITLE
Fix the workspace cleaner

### DIFF
--- a/ci-nodes/management/clean-workspaces.groovy
+++ b/ci-nodes/management/clean-workspaces.groovy
@@ -4,14 +4,22 @@ import hudson.slaves.OfflineCause;
 for (node in Hudson.getInstance().getNodes())
 {
   if (node.getComputer().isIdle()) {
-    println("Cleaning node.name");
-    println("  Attempting to take " + node.name + " offline.");
+    println("Cleaning " + node.name);
+    if (node.getComputer().isOffline()) {
+      println("  Offline, skipping");
+      continue
+    }
+    
+    println("  Attempting to take offline.");
    	node.getComputer().setTemporarilyOffline(true);
+    if (!node.getComputer().isIdle()) {
+      	println("  Not idle after offline, skipping!");
+        node.getComputer().setTemporarilyOffline(false);
+        continue;
+    }
     println("  Cleaning workspace");
     def workspacePath = node.getRootPath();
-    println("  About to wipe" + workspacePath.getRemote());
-    // Bring back online
-    println("  Done, bringing back online.");
+    println("  About to wipe " + workspacePath.getRemote());
     if (workspacePath.exists())
     {
       try {
@@ -25,6 +33,8 @@ for (node in Hudson.getInstance().getNodes())
     {
       println("  Nothing to delete at " + workspacePath)
     }
+    // Bring back online
+    println("  Done, bringing back online.");
     node.getComputer().setTemporarilyOffline(false);
   }
 }


### PR DESCRIPTION
Should avoid changing offline nodes, improve logging, etc.  This script now runs every few hours to periodically clean the disks