### PR TITLE
Initial multi-branch support

### DIFF
--- a/jobs/data/repolist.txt
+++ b/jobs/data/repolist.txt
@@ -1,17 +1,25 @@
-# List of repositories that are under control of JIT CI
-# Place one element per line in <org>/<project> format
+# List of repositories that are under control of .NET CI.  
+# Format is:
+# One repo per line (org/repo format).
+# Optional elements:
+#   folder=folderName (special case <root> for root folder.  forward slashes to separate subfolders)
+#   branch=branchName (branch that should be generated).  Should be bare branch name.
+#       If ommitted, repo is not branch specific.  **Do not change this unless you know what you're doing**.
+#       Talk to @mmitche first.
+#       GithubBranchName is passed the value in branchName.
+#       Unless the folder name is specifically specified, a folder is created underneath the repo folder.  If no branch is specified,
+#       no branch folder is created.
 # Example: dotnet/coreclr
-# This file is currently non-functional
 
 dotnet/buildtools
-dotnet/cli
+dotnet/cli branch=rel/1.0.0
 dotnet/codeformatter
 dotnet/coreclr
 dotnet/corefx
 dotnet/corefxlab
 dotnet/corert
 dotnet/orleans
-dotnet/roslyn <root>
+dotnet/roslyn folder=<root>
 dotnet/wcf
 Microsoft/ChakraCore
 Microsoft/ConcordExtensibilitySamples

--- a/jobs/generation/MetaGenerator.groovy
+++ b/jobs/generation/MetaGenerator.groovy
@@ -17,146 +17,238 @@ import jobs.generation.Utilities
 //  should recognize when there is a functional change being made and rerun all of the
 //  generated jobs.
 
+class Repo {
+    String project;
+    String[] folders;
+    String branchName;
+    
+    Repo(String project, String[] folders, String[] branchName) {
+        this.project = project
+        this.folders = folders
+        this.branchName = branchName
+    }
+    
+    // Parse the input string and return a Repo object
+    def static parseInputString(String input) {
+        // First element is the repo name.  Should be in <org>/<repo> format
+        def projectInfo = line.tokenize()
+        
+        assert projectInfo.size() >= 1
+        
+        // First element is the repo name
+        def project = projectInfo[0]
+        def folders = null
+        def branch = null
+        
+        println("Processing project ${project}")
+        
+        // Check whether it contains a single forward slash
+        assert project.indexOf('/') != -1 && project.indexOf('/') == project.lastIndexOf('/')
+        
+        // Now walk the rest of the elements and set the rest of the properties
+        def i = 1
+        while (i < (projectInfo.size()-1)) {
+            def element = projectInfo[i]
+            
+            if (element.startsWith('folder=')) {
+                // Parse out the folder names
+                folders = element.substring('folder='.length()).tokenize('/')
+                
+                // If the folder name was root, just zero it out.  If they chose root, there should
+                // only be one element
+                assert folders.size() >= 1
+                
+                if (folders[0] == '<root>') {
+                    assert folders.size() == 1
+                    // Set an initial empty folder
+                    folders = []
+                }
+            }
+            else if(element.startsWith('branch=')) {
+                branch = element.substring('branch='.length())
+            }
+            else {
+                println("Unknown element " + element);
+                assert false
+            }
+        }
+        
+        // If the folder was unset but branch was set to something, then we set the folder to the
+        // repo name plus branch subfolder
+        
+        if (folders == null) {
+            folders = [Utilities.getFolderName(project)]
+            if (branch == null) {
+                branch = 'master'
+            }
+            else {
+                // Append the branch name to the folder list
+                folders += branch
+            }
+        }
+        else {
+            // Folder already set, but set a default value for branch if it's not specified
+            // Branch name is not appended to the folder list.
+            if (branch == null) {
+                branch = 'master'
+            }
+        }
+        
+        println("   folders = ${folders}")
+        println("   branch = ${branch}")
+        
+        // Construct a new object and return
+        
+        return new Repo(project, folders, branch)
+    }
+}
+
+Repo[] repos
+
 streamFileFromWorkspace('dotnet-ci/jobs/data/repolist.txt').eachLine { line ->
     // Skip comment lines
     boolean skip = (line ==~ / *#.*/);
     line.trim()
     skip |= (line == '')
-    if (!skip) {
-        // Tokenize the line into columns.  If there is a second column, it is the root folder that the
-        // the jobs should go in (vs. the repo name)
-        def projectInfo = line.tokenize()
-        assert projectInfo.size() == 1 || projectInfo.size() == 2 : "Line ${line} should have at least a project name"
-        def project = projectInfo[0]
-       	// Create a folder for the project
-        def generatorFolder = Utilities.getFolderName(project)
-        if (projectInfo.size() == 2) {
-            generatorFolder = projectInfo[1]
-            if (generatorFolder == '<root>') {
-                generatorFolder = ''
-            }
+    if (skip) {
+        // Retunr from closure
+        return;
+    }
+    
+    
+    repos += parseInputString.parseInputString(line)
+}
+
+// Now that we have all the repos, generate the jobs
+repos.each { repoInfo ->
+    // Make the folders
+    def generatorFolder = ''
+    for (folderElement in repoInfo.folders) {
+        if (generatorFolder == '') {
+            generatorFolder = folderElement
+            folder(generatorFolder) {}
         }
-        
-        def generatorPRTestFolder = "${generatorFolder}/GenPRTest"
-        
-        if (generatorFolder != '') {
-      	  folder(generatorFolder) {}
+        else {
+            // Append a new folder
+            generatorFolder += "/${folderElement}"
         }
-        
-        // Create a Folder for generator PR tests under that.
-        folder(generatorPRTestFolder) {}
-        
-        [true, false].each { isPRTest ->
-            def jobGenerator = job(Utilities.getFullJobName(project, 'generator', isPRTest, isPRTest ? generatorPRTestFolder : generatorFolder)) {
-                // Need multiple scm's
-                multiscm {
-                    git {
-                        remote {
-                            github('dotnet/dotnet-ci')
-                        }
-                        relativeTargetDir('dotnet-ci')
-                        branch('*/master')
+    }
+    
+    // Make the PR test folder
+    def generatorPRTestFolder = "${generatorFolder}/GenPRTest"
+    
+    if (generatorFolder != '') {
+      folder(generatorFolder) {}
+    }
+    
+    // Create a Folder for generator PR tests under that.
+    folder(generatorPRTestFolder) {}
+    
+    [true, false].each { isPRTest ->
+        def jobGenerator = job(Utilities.getFullJobName(repoInfo.project, 'generator', isPRTest, isPRTest ? generatorPRTestFolder : generatorFolder)) {
+            // Need multiple scm's
+            multiscm {
+                git {
+                    remote {
+                        github('dotnet/dotnet-ci')
                     }
-                    // 
-                    git {
-                        remote {
-                            github(project)
-                            
-                            if (isPRTest) {
-                                refspec('+refs/pull/*:refs/remotes/origin/pr/*')
-                            }
-                        }
-                        // Want the relative to be just the project name
-                        relativeTargetDir(Utilities.getProjectName(project))
-                        
-                        // If PR, change to ${sha1} 
-                        if (isPRTest) {
-                            branch('${sha1}')
-                        }
-                        else {
-                            branch('*/master')
-                        }
-                    }
+                    relativeTargetDir('dotnet-ci')
+                    // dotnet-ci always pulls from master
+                    branch('*/master')
                 }
-                
-                // Add a parameter for the project, so that gets passed to the
-                // netci.groovy file
-                parameters {
-                    stringParam('GithubProject', project, 'Project name passed to the netci generator')
-                }
-                
-                // Add in the job generator logic
-                
-                steps {
-                    dsl {
-                        // Loads netci.groovy
-                        external(Utilities.getProjectName(project) + '/netci.groovy')
+                // 
+                git {
+                    remote {
+                        github(repoInfo.project)
                         
-                        // Additional classpath should point to the utility repo
-                        additionalClasspath('dotnet-ci')
-                        
-                        // Generate jobs relative to the seed job.        
-                        lookupStrategy('SEED_JOB')
-                        
-                        // PR tests should do nothing with the other jobs.
-                        // Non-PR tests should disable the jobs, which will get cleaned
-                        // up later.
                         if (isPRTest) {
-                            removeAction('IGNORE')
+                            refspec('+refs/pull/*:refs/remotes/origin/pr/*')
                         }
-                        else {
-                            removeAction('DISABLE')
-                        }
-                        removeViewAction('DELETE')
                     }
+                    // Want the relative to be just the project name
+                    relativeTargetDir(Utilities.getProjectName(repoInfo.project))
                     
-                    // If this is a PR test job, we don't want the generated jobs
-                    // to actually trigger (say on a github PR, since that will be confusing
-                    // and wasteful.  We can accomplish this by adding another DSL step that does
-                    // nothing.  It will generate no jobs, but the remove action is DISABLE so the
-                    // jobs generated in the previous step will be disabled.
-                    
+                    // If PR, change to ${sha1} 
+                    // If not a PR, then the branch name should be the target branch
                     if (isPRTest) {
-                        dsl {
-                             text('// Generate no jobs so the previously generated jobs are disabled')
-                        
-                             // Generate jobs relative to the seed job.        
-                             lookupStrategy('SEED_JOB')
-                             removeAction('DISABLE')
-                             removeViewAction('DELETE')
-                        }
+                        branch('${sha1}')
                     }
-                }
-                
-                // Enable concurrent builds 
-                concurrentBuild()
-
-                // Enable the log rotator
-
-                logRotator {    
-                    artifactDaysToKeep(7)
-                    daysToKeep(21)
-                    artifactNumToKeep(25)
+                    else {
+                        branch("*/${repoInfo.branch}")
+                    }
                 }
             }
             
-            // jobGenerator.with {
-                // Disable concurrency
-                // concurrentBuild(false)
+            // Add a parameter for the project, so that gets passed to the
+            // netci.groovy file
+            parameters {
+                stringParam('GithubProject', repoInfo.project, 'Project name passed to the netci generator')
+                stringParam('GithubBranchName', repoInfo.branch, 'Branch name passed to the netci generator')
+            }
+            
+            // Add in the job generator logic
+            
+            steps {
+                dsl {
+                    // Loads netci.groovy
+                    external(Utilities.getProjectName(project) + '/netci.groovy')
+                    
+                    // Additional classpath should point to the utility repo
+                    additionalClasspath('dotnet-ci')
+                    
+                    // Generate jobs relative to the seed job.        
+                    lookupStrategy('SEED_JOB')
+                    
+                    // PR tests should do nothing with the other jobs.
+                    // Non-PR tests should disable the jobs, which will get cleaned
+                    // up later.
+                    if (isPRTest) {
+                        removeAction('IGNORE')
+                    }
+                    else {
+                        removeAction('DISABLE')
+                    }
+                    removeViewAction('DELETE')
+                }
                 
-                // Disable concurrency across all generators 
-                // throttleConcurrentBuilds {
-                //  throttleDisabled(false)
-                //  maxTotal(1)
-                //  maxPerNode(1)
-                //  categories(['job_generators'])
-                // }
-            // }
+                // If this is a PR test job, we don't want the generated jobs
+                // to actually trigger (say on a github PR, since that will be confusing
+                // and wasteful.  We can accomplish this by adding another DSL step that does
+                // nothing.  It will generate no jobs, but the remove action is DISABLE so the
+                // jobs generated in the previous step will be disabled.
+                
+                if (isPRTest) {
+                    dsl {
+                         text('// Generate no jobs so the previously generated jobs are disabled')
+                    
+                         // Generate jobs relative to the seed job.        
+                         lookupStrategy('SEED_JOB')
+                         removeAction('DISABLE')
+                         removeViewAction('DELETE')
+                    }
+                }
+            }
+            
+            // Enable concurrent builds 
+            concurrentBuild()
+
+            // Enable the log rotator
+
+            logRotator {    
+                artifactDaysToKeep(7)
+                daysToKeep(21)
+                artifactNumToKeep(25)
+            }
+        }
+        
+        if (isPRTest) {
+            // Enable the github PR trigger, but add a trigger phrase so
+            // that it doesn't build on every change.
             
             if (isPRTest) {
                 // Enable the github PR trigger, but add a trigger phrase so
                 // that it doesn't build on every change.
-                Utilities.addGithubPRTrigger(jobGenerator, jobGenerator.name, '(?i).*test\\W+ci\\W+please.*')
+                Utilities.addGithubPRTriggerForBranch(jobGenerator, repoInfo.branch, jobGenerator.name, '(?i).*test\\W+ci\\W+please.*')
             }
             else {
                 // Enable the github push trigger


### PR DESCRIPTION
This change makes multi-branch support possible in Jenkins.  It extends the list of of configuration properties for a repo to a branch name.  If a branch name is specified, a branch specific folder is generated underneath the repo name.  GithubBranchName is passed to netci.groovy while generating, and should be used when setting up jobs (Utilities.standardJobSetup, addStandardParameters)