### PR TITLE
Use days to keep vs. num to keep to improve logRotator performance.

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -271,9 +271,10 @@ class Utilities {
             // Enable the log rotator
 
             logRotator {    
-                artifactDaysToKeep(21)
-                daysToKeep(90)
-                artifactNumToKeep(50)
+                artifactDaysToKeep(14)
+                daysToKeep(30)
+                artifactNumToKeep(-1)
+                numToKeep(-1)
             }
             
             wrappers {


### PR DESCRIPTION
The perf issue has been reported in https://issues.jenkins-ci.org/browse/JENKINS-32371