### PR TITLE
Avoid skipping builds for non-PR if netci is changed.

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -322,8 +322,10 @@ class Utilities {
             }
         }
 
-        // Add netci.groovy as default
-        Utilities.addIgnoredPaths(job, ['netci.groovy']);
+        // Add netci.groovy as default.  Only add if it's a PR.
+        if (isPR) {
+            Utilities.addIgnoredPaths(job, ['netci.groovy']);
+        }
         Utilities.setJobTimeout(job, 120)
         Utilities.addRetentionPolicy(job, isPR)
     }


### PR DESCRIPTION
Avoids cases where we get a 'notbuilt' badge or odd cases where we are missing artifacts