### PR TITLE
Add nano server image to jenkins jobs.

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -156,6 +156,11 @@ class Utilities {
                                 // the generic unversioned label except for special cases.
                                 'latest-or-auto':'auto-win2016-20160222'
                                 ],
+                            'Windows Nano' :
+                                [
+                                // Generic version label
+                                '' : 'nanotp4'
+                                ],
                             'Windows 10' : 
                                 [
                                 // Generic version label


### PR DESCRIPTION
cc @mmitche @joshfree 

This image is currently on my local box, since azure Nano server image doesn't have many of the required featured turned on. The other option is to use a custom vhd and upload to azure. Looking into doing it, but using this local vm now for testing purposes.