### PR TITLE
Update setMachineAffinity for Windows 2016

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -147,14 +147,14 @@ class Utilities {
                                 // the generic unversioned label except for special cases.
                                 'latest-or-auto':'windows'
                                 ],
-                            'Windows 2016' : 
+                            'Windows_2016' : 
                                 [
                                 // Generic version label
-                                '' : 'auto-win2016-20160222',
+                                '' : 'auto-win2016-20160223',
                                 // Latest auto image.  This will be used for transitioning
                                 // to the auto images, at which point we will move back to
                                 // the generic unversioned label except for special cases.
-                                'latest-or-auto':'auto-win2016-20160222'
+                                'latest-or-auto':'auto-win2016-20160223'
                                 ],
                             'Windows 10' : 
                                 [


### PR DESCRIPTION
- "Windows 2016" should have an underscore to match Windows_NT
- Update the image to the latest version

cc: @mmitche 