### PR TITLE
Fix private PR triggers

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -419,9 +419,16 @@ class Utilities {
                     else {
                         assert permittedOrgs != null || permittedUsers != null
                         permitAll(false)
-                        orgWhitelist(permittedOrgs)
-                        userWhitelist(permittedUsers)
-                        allowMembersOfWhitelistedOrgsAsAdmin()
+                        if (permittedUsers != null) {
+                            permittedUsers.each { permittedUser ->
+                                admin(permittedUser)
+                            }
+                        }
+                        if (permittedOrgs != null) {
+                            permittedOrgs.each { permittedOrg ->
+                                admin(permittedOrg)
+                            }
+                        }
                     }
                     extensions {
                         commitStatus {


### PR DESCRIPTION
On private PRs triggers, permitted orgs and users should be admins, so they may request for others.

fyi @jashook