### PR TITLE
Add new label that corresponds to windows machines and auto machines

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -148,7 +148,11 @@ class Utilities {
                                 // Latest auto image.  This will be used for transitioning
                                 // to the auto images, at which point we will move back to
                                 // the generic unversioned label except for special cases.
-                                'latest-or-auto':'windows'
+                                'latest-or-auto':'windows',
+                                // For testing and transition
+                                'latest-or-auto-temp':'windows || auto-win2012-20160311.1',
+                                // For elevated runs
+                                'latest-or-auto-elevated-temp':'windows-elevated || auto-win2012-20160311.1-elevated'
                                 ],
                             'Windows_2016' : 
                                 [


### PR DESCRIPTION
Adds 'latest-or-auto-temp' version that corresponds to 'windows || <dynamic image version'.  Will be used during rollout of the Windows dynamic scaling
Add temp label for elevated