### PR TITLE
Add automatic workspace requirement for flow jobs

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -348,12 +348,21 @@ class Utilities {
                     cleanWhenUnstable(true)
                 }
             }
+
+            if (job instanceof javaposse.jobdsl.dsl.jobs.BuildFlowJob) {
+                // Needs a workspace to avoid building other branches when not needed.
+                configure {
+                    def buildNeedsWorkspace = it / 'buildNeedsWorkspace'
+                    buildNeedsWorkspace.setValue('true')
+                }
+            }
         }
 
         // Add netci.groovy as default.  Only add if it's a PR.
         if (isPR) {
             Utilities.addIgnoredPaths(job, ['netci.groovy']);
         }
+
         Utilities.setJobTimeout(job, 120)
         Utilities.addRetentionPolicy(job, isPR)
     }


### PR DESCRIPTION
In order to avoid building more than just the target branch, flow runs need to have a workspace

/cc @Priya91 