### PR TITLE
Root generator

### DIFF
--- a/jobs/generation/RootGenerator.groovy
+++ b/jobs/generation/RootGenerator.groovy
@@ -1,2 +1,138 @@
-// This file should contains the code to generate the root generator, which
-// watches repolist.txt
+// This file generates all of the root jobs in a repo.  Basic generators, cleaners, etc.
+// Does not use any utility functionality to make setup easy
+
+
+// Create the main generator.
+job("dotnet_dotnet-ci_generator") {
+    logRotator {
+        daysToKeep(7)
+    }
+    
+    // Source is just basic git for dotnet-ci
+    scm {
+        git {
+            remote {
+                github("dotnet/dotnet-ci")
+            }
+            branch("*/master")
+            
+          	relativeTargetDir('dotnet-ci')
+        }
+    }
+    
+    // Add a parameter which is the server name (incoming parameter to this job
+    parameters {
+        stringParam('ServerName', ServerName, "Server that this generator is running on")
+    }
+
+    // No concurrency, throttle among the other generators.
+    // Not entirely sure this is required, but this is how it is today
+    concurrentBuild(false)
+    throttleConcurrentBuilds {
+        throttleDisabled(false)
+        maxTotal(0)
+        maxPerNode(1)
+        categories(['job_generators'])
+    }
+    
+    // Trigger a build when a change is pushed
+    triggers {
+        githubPush()
+    }
+    
+    // Step is "process job dsls"
+    steps {
+        dsl {
+            // Loads netci.groovy
+            external('dotnet-ci/jobs/generation/MetaGenerator.groovy')
+            
+            // Additional classpath should point to the utility repo
+            additionalClasspath('dotnet-ci')
+            
+            // Generate jobs relative to the seed job.        
+            lookupStrategy('JENKINS_ROOT')
+            
+            removeAction('DISABLE')
+            removeViewAction('DELETE')
+        }
+    }
+}
+
+// Create the job disabler
+job('disable_jobs_in_folder') {
+    logRotator {
+        daysToKeep(7)
+    }
+    
+    // Set up parameters
+    parameters {
+        booleanParam('DryRunOnly', true, 'Do not actually disable jobs, just indicate what jobs would be disabled')
+        booleanParam('DisableSubFolderItems', false, 'Disable items in subfolders of the target folder')
+        stringParam('FolderName', '', 'Folder to disable.  Root folder not allowed')
+    }
+    
+    scm {
+        git {
+            remote {
+                github('dotnet/dotnet-ci')
+            }
+            branch("*/master")
+        }
+    }
+    
+    steps {
+        systemGroovyScriptFile('jobs/scripts/disable_jobs_in_folder.groovy')
+    }
+}
+
+// Create the workspace cleaner
+job('workspace_cleaner') {
+    logRotator {
+        daysToKeep(7)
+    }
+    
+    logRotator {
+        daysToKeep(7)
+    }
+    
+    scm {
+        git {
+            remote {
+                github('dotnet/dotnet-ci')
+            }
+            branch("*/master")
+        }
+    }
+    
+    triggers {
+        cron('0 0 * * *')
+    }
+    
+    steps {
+        systemGroovyScriptFile('jobs/scripts/workspace_cleaner.groovy')
+    }
+}
+
+// Create the system cleaner
+job('system_cleaner') {
+    logRotator {
+        daysToKeep(7)
+    }
+    
+    scm {
+        git {
+            remote {
+                github('dotnet/dotnet-ci')
+            }
+            branch("*/master")
+        }
+    }
+    
+    triggers {
+        cron('0 0 * * *')
+    }
+    
+    steps {
+        systemGroovyScriptFile('jobs/scripts/system_cleaner.groovy')
+    }
+}

--- a/jobs/scripts/disable_jobs_in_folder.groovy
+++ b/jobs/scripts/disable_jobs_in_folder.groovy
@@ -1,0 +1,45 @@
+import hudson.model.*
+import jenkins.model.*
+  
+// Grab the parameters
+
+def resolver = build.buildVariableResolver
+String FolderName = resolver.resolve("FolderName").toString()
+boolean DisableSubFolderItems = resolver.resolve("DisableSubFolderItems").toString().toBoolean()
+boolean DryRunOnly = resolver.resolve("DryRunOnly").toBoolean()
+assert FolderName != '' && FolderName != '/'
+if (!FolderName.startsWith('/')) {
+    FolderName = "/" + FolderName
+}
+
+print ('Disabling jobs in ' + FolderName)
+if (DisableSubFolderItems) {
+	print (' and any folders under that')
+}
+if (DryRunOnly) {
+  	print ('  (dry run)')
+}
+
+// Disable a folder for deletion later.
+disableFolder(FolderName, DryRunOnly, DisableSubFolderItems, Jenkins.instance.items)
+
+def disableFolder(String folderName, boolean dryRunOnly, boolean disableSubfolders, items, String currentFolderName = '') {
+  for (item in items) {
+    if (item.class.canonicalName != 'com.cloudbees.hudson.plugins.folder.Folder') {
+      if (folderName == currentFolderName || (disableSubfolders && currentFolderName.startsWith(folderName))) {
+        if (!dryRunOnly) {
+            println ("Disabling ${currentFolderName}/" + item.name);
+            item.disabled=true
+            item.save()
+        }
+        else {
+            println ("Would Disable ${currentFolderName}/" + item.name);
+        }
+      }
+    } else {
+      if (folderName != currentFolderName || disableSubfolders) {
+		disableFolder(folderName, dryRunOnly, disableSubfolders, ((com.cloudbees.hudson.plugins.folder.Folder) item).getItems(), currentFolderName + "/" + item.name)
+      }
+    }
+  }
+}

--- a/jobs/scripts/system_cleaner.groovy
+++ b/jobs/scripts/system_cleaner.groovy
@@ -1,0 +1,18 @@
+import hudson.model.*
+import jenkins.model.*
+
+
+deleteDisabledNonRootChildren(Jenkins.instance.items, '')
+
+def deleteDisabledNonRootChildren(items, folder) {
+  for (item in items) {
+    if (item.class.canonicalName != 'com.cloudbees.hudson.plugins.folder.Folder') {
+      if (folder != '' && item.disabled) {
+        println("About to delete " + folder + "/" + item.name)
+        item.delete();
+      }
+    } else {
+      deleteDisabledNonRootChildren(((com.cloudbees.hudson.plugins.folder.Folder) item).getItems(), folder + "/" + item.name)
+    }
+  }
+}

--- a/jobs/scripts/workspace_cleaner.groovy
+++ b/jobs/scripts/workspace_cleaner.groovy
@@ -1,0 +1,82 @@
+import hudson.model.*
+import hudson.slaves.OfflineCause;
+  
+for (node in Hudson.getInstance().getNodes())
+{
+  println("Checking " + node.name);
+  def computer = node.getComputer()
+  if (computer.isIdle())
+  {
+    println("  Cleaning " + node.name);
+    if (node.getComputer().isOffline()) {
+      println("  Offline, skipping");
+      continue
+    }
+    
+    println("  Attempting to take offline.");
+   	computer.setTemporarilyOffline(true);
+    if (!computer.isIdle()) {
+      	println("  Not idle after offline, skipping!");
+        computer.setTemporarilyOffline(false);
+        continue;
+    }
+    println("  Cleaning workspace");
+    def workspacePath = node.getRootPath();
+    println("  About to wipe" + workspacePath.getRemote());
+    if (workspacePath.exists())
+    {
+      try {
+        deleteDirContents(computer, workspacePath, out)
+        println("  Deleted from location " + workspacePath)
+      } catch(e) {
+        println("  Delete failed with: " + e)
+      }
+    }
+    else
+    {
+      println("  Nothing to delete at " + workspacePath)
+    }
+    // Grab the temp dir
+    def tempPath = computer.getEnvironment().get('TEMP', null)
+    if (tempPath != null) {
+      def tempFilePath = node.createPath(tempPath);
+      println("  Cleaning temp path: " + tempFilePath.getRemote())
+      if (tempFilePath.exists()) {
+        deleteDirContents(computer, tempFilePath, out)
+      }
+    }
+    else {
+      // Try /tmp/
+      def tempFilePath = node.createPath('/tmp/');
+      println("  Cleaning temp path: " + tempFilePath.getRemote())
+      if (tempFilePath.exists()) {
+        deleteDirContents(computer, tempFilePath, out)
+      }
+    }
+    // Bring back online
+    println("  Done, bringing back online.");
+    computer.setTemporarilyOffline(false);
+  }
+  else {
+    println("  Not Idle");
+  }
+}
+
+def static deleteDirContents(def computer, def directory, def output) {
+  def command = ''
+  if (computer.isUnix()) {
+    command = "/bin/sh -c 'rm -rf *'"
+  } else {
+    command = "cmd.exe /C mkdir %USERPROFILE%\\emptydir & robocopy /MIR /NFL /NDL /NJH /NJS /nc /ns /np %USERPROFILE%\\emptydir ${directory}"
+  }
+      
+  try {
+    output.println ("   Running ${command}")
+    def launcher = directory.createLauncher(hudson.model.TaskListener.NULL);
+    def starter = launcher.launch().pwd(directory).stdout(output).stderr(output).cmdAsSingleString(command)
+    starter.join()
+  }
+  catch(e) {
+    output.println("    Failed to deleteDirContents on " + directory)
+  }
+}


### PR DESCRIPTION
Builds up the basic jobs for dotnet-ci instances.  To use, create a new freestyle job with source control pointing to dotnet-ci and process job DSLs in the jobs/generation/RootGenerator.groovy script file, then run.  Job should be set to run on pushes to dotnet-ci