### PR TITLE
Allow for multiple DSL definitions

### DIFF
--- a/jobs/data/repolist.txt
+++ b/jobs/data/repolist.txt
@@ -9,10 +9,13 @@
 #       GithubBranchName is passed the value in branchName.
 #       Unless the folder name is specifically specified, a folder is created underneath the repo folder.  If no branch is specified,
 #       no branch folder is created.
+#   definitionScript=<file path> Path to the location of the groovy file that should be used for this
+#       entry.  Path is relative to the root of the repository.  Usually ommitted.  Can default to
 # Example: dotnet/coreclr
 
 dotnet/buildtools branch=master server=dotnet-ci
 dotnet/citest branch=master server=dotnet-ci2
+dotnet/citest folder=dotnet_citest/perf/master definitionScript=perf.groovy branch=master server=dotnet-ci2
 dotnet/cli branch=rel/1.0.0 server=dotnet-ci
 dotnet/cli branch=master server=dotnet-ci
 dotnet/codeformatter branch=master server=dotnet-ci


### PR DESCRIPTION
This change allows for multiple groovy files to be used. They can also target different servers if desired.  This is motivated by some teams' desires to move CI definitions into subdirectories, as well as a desire to have a separate perf server.  We can put the perf definitions in another file which runs on the other server.

@dilijev This should allow you to move your CI definition if you like too