### PR TITLE
arm32 correctly setup on VM.

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -97,7 +97,7 @@ class Utilities {
                                 '20160211':'auto-ubuntu1404-20160211',
                                 // Contains the rootfs setup for arm/arm64 builds.  Move this label forward
                                 // till we have the working build/test, then apply to everything.
-                                'arm-cross-latest':'auto-ubuntu1404-20160509',
+                                'arm-cross-latest':'auto-ubuntu1404-20160524',
                                 // Latest auto image.  This will be used for transitioning
                                 // to the auto images, at which point we will move back to
                                 // the generic unversioned label except for special cases.


### PR DESCRIPTION
The commit changes the arm32 auto vm to use the most up to date vm with
the simulator mounted at /opt/