### PR TITLE
Use SCM polling for cron triggers

### DIFF
--- a/jobs/generation/JobReport.groovy
+++ b/jobs/generation/JobReport.groovy
@@ -4,6 +4,7 @@ class JobReport {
     class CronTriggerInfo {
         String cronString
         String[] branches
+        boolean alwaysRuns
     }
     class PRTriggerInfo {
         String context
@@ -81,10 +82,11 @@ class JobReport {
         addReference(jobName)
     }
     
-    def addCronTriggeredJob(String jobName, String cronString) {
+    def addCronTriggeredJob(String jobName, String cronString, boolean alwaysRuns) {
         def triggerInfo = new CronTriggerInfo()
         triggerInfo.cronString = cronString
         triggerInfo.branches = getTargetBranchesForJob(jobName)
+        triggerInfo.alwaysRuns = alwaysRuns
         
         cronTriggeredJobs += ["${jobName}":triggerInfo]
         addReference(jobName)
@@ -174,14 +176,15 @@ class JobReport {
         // Cron trigger CSV report
         
         outStream.println()
-        outStream.println("Push Job CSV")
+        outStream.println("Cron Job CSV")
         outStream.println("================================================================")
         
-        def cronTriggerFormatString = "%s,%s,%s"
-        outStream.println(String.format(cronTriggerFormatString, "Job Name", "Cron", "Branches"))
+        def cronTriggerFormatString = "%s,%s,%s,%s"
+        outStream.println(String.format(cronTriggerFormatString, "Job Name", "Cron", "Branches", "Always Runs?"))
         cronTriggeredJobs.sort().each { jobName, triggerInfo -> 
             String branchString = triggerInfo.branches == null ? 'All' : triggerInfo.branches.join('; ')
-            outStream.println(String.format(cronTriggerFormatString, jobName, triggerInfo.cronString, branchString))
+            String alwaysRunsString = triggerInfo.alwaysRuns ? 'Yes' : 'No'
+            outStream.println(String.format(cronTriggerFormatString, jobName, triggerInfo.cronString, branchString, alwaysRunsString))
         }
         outStream.println("================================================================")
     }

--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -823,15 +823,28 @@ class Utilities {
             }
         }
     }
-
-    def static addPeriodicTrigger(def job, String cronString) {
+    
+    // Adds a trigger that causes the job to run on a schedule.
+    // If alwaysRuns is true, then this is a true cron trigger.  If false,
+    // then only runs if source control has changed
+    // Parameters:
+    //
+    //  job - Job to modify
+    //  cronString - Cron job string indicating the frequency
+    //  alwaysRuns - If true, the job will be a true cron job, if false, will run only when source has changed
+    def static addPeriodicTrigger(def job, String cronString, boolean alwaysRuns = false) {
         job.with {
             triggers {
-                cron(cronString)
+                if (alwaysRuns) {
+                    cron(cronString)
+                }
+                else {
+                    scm(cronString)
+                }
             }
         }
         
-        JobReport.Report.addCronTriggeredJob(job.name, cronString)
+        JobReport.Report.addCronTriggeredJob(job.name, cronString, alwaysRuns)
     }
     
     // Adds xunit.NET v2 test results.


### PR DESCRIPTION
To avoid unnecessary runs, we use an SCM poll as the cron trigger, unless alwaysRun = true (new last parameter of addPeriodicTrigger)