### PR TITLE
Workaround issue in job-dsl-plugin

### DIFF
--- a/jobs/generation/MetaGenerator.groovy
+++ b/jobs/generation/MetaGenerator.groovy
@@ -164,7 +164,7 @@ repos.each { repoInfo ->
             multiscm {
                 git {
                     remote {
-                        github('dotnet/dotnet-ci')
+                        url('https://github.com/dotnet/dotnet-ci')
                     }
                     relativeTargetDir('dotnet-ci')
                     // dotnet-ci always pulls from master


### PR DESCRIPTION
Under newer versions of the job-dsl-plugin, the ghprb trigger startup appears to be getting the older value of the github project property rather than the newest one written (the generator sets it twice).  This causes us to start triggers improperly for the ci test projects.  Work around this by instead just setting the URL and then the github project property.