### PR TITLE
Allow for more fine grained control over PR branch triggers

### DIFF
--- a/jobs/data/repolist.txt
+++ b/jobs/data/repolist.txt
@@ -11,7 +11,12 @@
 #       no branch folder is created.
 #   definitionScript=<file path> Path to the location of the groovy file that should be used for this
 #       entry.  Path is relative to the root of the repository.  Usually ommitted.  Can default to
-# Example: dotnet/coreclr
+#   isDefaultPRBranch=true/false (default: false)- If true, then:
+#       GithubPRTargetBranches = .* + current branch
+#       GithubPRSkipBranches = other tracked branches + other PR branches
+#   additionalPRBranches=<comma separated list of branches>
+#       GithubPRTargetBranches contains the list additional PR branch list + current branch
+#       GithubPRSkipBranches = other tracked branches + other PR branches
 
 dotnet/buildtools branch=master server=dotnet-ci
 dotnet/buildtools branch=release/1.0.0 server=dotnet-ci

--- a/jobs/generation/MetaGenerator.groovy
+++ b/jobs/generation/MetaGenerator.groovy
@@ -23,14 +23,36 @@ class Repo {
     String branch
     String server
     String definitionScript
+    // Indicates this is a branch for 'default' PRs. ORs to branches other than the tracked branches would use jobs
+    // defined here.  If true, then the generator will receive .* + branch +  for GithubPRTargetBranches with the other tracked
+    // branches  in the GithubPRSkipBranches parameter.
+    boolean isDefaultPRBranch
+    // Indicates this branch provides PR coverage for the listed branches.  If set, the GithubPRTargetBranches will be
+    // set to this branch + prsForBranches.  GithubPRSkipBranches remains empty
+    String[] additionalPRBranches = []
     
-    def Repo(String project, String[] folders, String branch, String server, String definitionScript) {
+    // Lazily set up data
+    // Branches that should be targeted for PRs against this job definition
+    String[] prTargetBranches 
+    // Branches that should be skipped for PRs against this job definition
+    String[] prSkipBranches 
+    
+    def Repo(String project, 
+             String[] folders,
+             String branch,
+             String server,
+             String definitionScript,
+             boolean isDefaultPRBranch,
+             String[] additionalPRBranches) {
+             
         this.project = project
         this.folders = folders
         this.branch = branch
         this.server = server
         this.definitionScript = definitionScript
-    }
+        this.isDefaultPRBranch = isDefaultPRBranch
+        this.additionalPRBranches = additionalPRBranches
+    }    
     
     // Parse the input string and return a Repo object
     def static parseInputString(String input, def out) {
@@ -47,6 +69,10 @@ class Repo {
         String server = 'dotnet-ci'
         // File name/path is usually netci.groovy, but can be set arbitrarily
         String definitionScript = 'netci.groovy'
+        // Additional PR branches
+        String[] additionalPRBranches = []
+        // Is the default PR branch?
+        boolean isDefaultPRBranch = false
         
         // Check whether it contains a single forward slash
         assert project.indexOf('/') != -1 && project.indexOf('/') == project.lastIndexOf('/')
@@ -79,6 +105,14 @@ class Repo {
             else if(element.startsWith('definitionScript=')) {
                 definitionScript = element.substring('definitionScript='.length())
             }
+            else if(element.startsWith('additionalPRBranches=')) {
+                // Parse out the folder names
+                additionalPRBranches = element.substring('additionalPRBranches='.length()).tokenize(',')
+            }
+            else if(element.startsWith('isDefaultPRBranch=')) {
+                // Parse out the folder names
+                isDefaultPRBranch = element.substring('isDefaultPRBranch='.length()).toBoolean()
+            }
             else {
                 println("Unknown element " + element);
                 assert false
@@ -107,12 +141,9 @@ class Repo {
             }
         }
         
-        out.println("   folders = ${folders}")
-        out.println("   branch = ${branch}")
-        
         // Construct a new object and return
         
-        return new Repo(project, folders, branch, server, definitionScript)
+        return new Repo(project, folders, branch, server, definitionScript, isDefaultPRBranch, additionalPRBranches)
     }
 }
 
@@ -129,6 +160,40 @@ streamFileFromWorkspace('dotnet-ci/jobs/data/repolist.txt').eachLine { line ->
     }
     
     repos += Repo.parseInputString(line, out)
+}
+
+// Post Processing
+// Process each repo and determine the other tracked branches, the PR target branches,
+// and the PR skip branches
+
+repos.each { repoInfo ->
+    def otherRepos = repos.findAll { searchRepoInfo -> 
+        // Same project
+        searchRepoInfo.project == repoInfo.project &&
+        // Different branch
+        searchRepoInfo.branch != repoInfo.branch
+    }
+    
+    repoInfo.prTargetBranches = []
+    repoInfo.prSkipBranches = []
+    
+    // Determine the prTargetBranches and prSkipBranches
+    if (repoInfo.isDefaultPRBranch) {
+        // If we're the default PR branch, the pr target branch is set to .*
+        repoInfo.prTargetBranches = ['.*']
+        repoInfo.prSkipBranches = otherRepos.branch + otherRepos.additionalPRBranches.flatten()
+    }
+    else {
+        // Otherwise, the target branch is the branch + additional Branches
+        repoInfo.prTargetBranches = repoInfo.additionalPRBranches
+        repoInfo.prSkipBranches = otherRepos.branch + otherRepos.additionalPRBranches.flatten()
+    }
+    repoInfo.prTargetBranches += ((String[])[repoInfo.branch])
+    
+    repoInfo.prTargetBranches = repoInfo.prTargetBranches.toUnique()
+    repoInfo.prSkipBranches = repoInfo.prSkipBranches.toUnique()
+    
+    println("${repoInfo.project} - ${repoInfo.branch}\n    PR Target Branches = ${repoInfo.prTargetBranches}\n     PR Skip Branches = ${repoInfo.prSkipBranches}")
 }
 
 // Now that we have all the repos, generate the jobs
@@ -209,6 +274,8 @@ repos.each { repoInfo ->
             parameters {
                 stringParam('GithubProject', repoInfo.project, 'Project name passed to the DSL generator')
                 stringParam('GithubBranchName', repoInfo.branch, 'Branch name passed to the DSL generator')
+                stringParam('GithubPRTargetBranches', repoInfo.prTargetBranches.join(','), 'Branches that should be tracked for PRs')
+                stringParam('GithubPRSkipBranches', repoInfo.prSkipBranches.join(','), 'Branches that should be skipped for PRs')
             }
             
             // Add in the job generator logic


### PR DESCRIPTION
Today most PR triggers are branch specific.  They only apply to the current branch.  This isn't great in cases where we are working on dev branches.  In these cases, we'd just like to use the PR definitions from another branch.  This commit, combined with forthcoming Github Pull Request Builder, begins to address this.  There are two primary features:

* Adding the ability to mark a branch as the "default" PR branch.
* Adding the ability to mark a branch definition as the PR definition for other branches (usually not mentioned in the repo list)

These properties control two build parameters:
GithubPRTargetBranches - Comma separated list of branches targeted by the CI definition which should be targeted for PRs
GithubPRSkipBranches - Comma separated list of branches targeted by the CI definition which should be skipped for PRs

If default were set, then target branches would be .*, but all other tracked branches for the repo would be in the skip list.

This needs:
* The GHPRB black list feature
* Updates in the Utilities functionality to understand the two lists (target and skip)
* Updates in the CI definitions to use the new functionality.