### PR TITLE
Bump Fedora Image

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -266,13 +266,13 @@ class Utilities {
                                 ],
                            'Fedora23' :
                                 [
-                                '' : 'auto-fedora23-20160530',
+                                '' : 'auto-fedora23-20160622',
                                 // Latest auto image.  This will be used for transitioning
                                 // to the auto images, at which point we will move back to
                                 // the generic unversioned label except for special cases.
-                                'latest-or-auto':'auto-fedora23-20160530',
+                                'latest-or-auto':'auto-fedora23-20160622',
                                 // For outerloop runs
-                                'outer-latest-or-auto':'auto-fedora23-20160530outer'
+                                'outer-latest-or-auto':'auto-fedora23-20160622outer'
                                 ],
                                 // Some nodes don't have git, which is what is required for the
                                 // generators.


### PR DESCRIPTION
This adds zip and unzip to the fedora images, which some infrastructure in CoreCLR needs.