### PR TITLE
Updating the 'latest-or-auto-internal' label to use the VS2015.3 image.

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -167,7 +167,7 @@ class Utilities {
                                 // Dev15 image
                                 'latest-dev15':'auto-win2012-20160506',
                                 // For internal runs
-                                'latest-or-auto-internal':'windows-internal || auto-win2012-20160325-internal',
+                                'latest-or-auto-internal':'windows-internal || auto-win2012-20160627-internal',
                                 // For elevated runs
                                 'latest-or-auto-elevated':'windows-elevated || auto-win2012-20160325-elevated'
                                 ],


### PR DESCRIPTION
FYI. @mmitche, @jasonmalinowski, @dotnet/roslyn-infrastructure 