### PR TITLE
Update Utilities.groovy to have an internal machine affinity label that does not include the static pool.

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -172,6 +172,8 @@ class Utilities {
                                 'latest-dev15':'auto-win2012-20160506',
                                 // For internal runs
                                 'latest-or-auto-internal':'windows-internal || auto-win2012-20160707-internal',
+                                // For internal runs which don't need/want the static 'windows-internal' pool
+                                'latest-dev15-internal':'auto-win2012-20160707-internal',
                                 // For elevated runs
                                 'latest-or-auto-elevated':'windows-elevated || auto-win2012-20160325-elevated'
                                 ],


### PR DESCRIPTION
FYI. @mmitche 