### PR TITLE
Increase the storage for the emulator fs

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -111,7 +111,7 @@ class Utilities {
                                 '20160211':'auto-ubuntu1404-20160211.1',
                                 // Contains the rootfs setup for arm/arm64 builds.  Move this label forward
                                 // till we have the working build/test, then apply to everything.
-                                'arm-cross-latest':'auto-ubuntu1404-20160711',
+                                'arm-cross-latest':'auto-ubuntu1404-20160818',
                                 // Latest auto image.  This will be used for transitioning
                                 // to the auto images, at which point we will move back to
                                 // the generic unversioned label except for special cases.


### PR DESCRIPTION
This change uses a captured vm with an 11gb ext4 filesystem for the arm
emulator runs in place of the 7gb it had before.