### PR TITLE
Add getBoostrapPublishRid function

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -88,6 +88,24 @@ class Utilities {
         return project.split('/')[0];
     }
 
+    // Define a set of OS names which can resore and use managed build tools with a non-default RID.
+    // This controls the __PUBLISH_RID environment variable which affects init-tools behavior.
+    // Entries placed in this list are temporary, and should be removed when NuGet packages are published
+    // for the new OS.
+    //
+    // Parameters:
+    //  os: The name of the operating system. Ex: Windows_NT, OSX, openSUSE42.1.
+    //
+    // Returns: The name of an alternate RID to use while bootstrapping. If no RID mapping exists, returns null.
+    def static getBoostrapPublishRid(def os) {
+        def bootstrapRidMap = [
+            'openSUSE42.1': 'opensuse.13.2-x64',
+            'Ubuntu16.10': 'ubuntu.16.04-x64',
+            'Fedora24': 'fedora.23-x64'
+        ]
+        return bootstrapRidMap.get(os, null)
+    }
+
     // Given the name of an OS, set the nodes that this job runs on.
     //
     // Parameters:


### PR DESCRIPTION
This adds a helper function which maps from an OS name ("Windows_NT", "Fedora24", etc) to a temporary "publish RID", which can be used to control which RID our init-tools script publishes for. It is intended to make bootstrapping the CI system for our repos easier.

Usage would be as follows, in coreclr for example:

Currently:

coreclr/netci.groovy
```groovy
case 'Ubuntu':
...
{
    buildCommands += "./build.sh verbose ${lowerConfiguration} ${arch}"
}
```

New:
```groovy
case 'Ubuntu':
case 'Ubuntu16.10':
...
else
{
    def bootstrapRid = Utilities.getBoostrapPublishRid(os)
    def bootstrapRidEnv = bootstrapRid != null ? '__PUBLISH_RID=${bootstrapRid} ' : ''
    buildCommands += "${bootstrapRidEnv}./build.sh verbose ${lowerConfiguration} ${arch}"
}
```

The `Ubuntu` build command will be the same, but `Ubuntu16.10` will have a temporary `__PUBLISH_RID=ubuntu.16.04-x64` environment variable before the command.

@ellismg 

FYI: @joperezr This is part of what I mentioned in our chat.