### PR TITLE
Remove dev branch of dotnet-docker-nightly

### DIFF
--- a/jobs/data/repolist.txt
+++ b/jobs/data/repolist.txt
@@ -41,7 +41,6 @@ dotnet/corefx branch=release/1.0.0-rc2 server=dotnet-ci
 dotnet/corefx branch=release/1.0.0 server=dotnet-ci
 dotnet/corefxlab branch=master server=dotnet-ci
 dotnet/corert branch=master server=dotnet-ci
-dotnet/dotnet-docker-nightly branch=dev server=dotnet-ci
 dotnet/dotnet-docker-nightly branch=master server=dotnet-ci
 dotnet/llilc branch=master server=dotnet-ci
 dotnet/orleans server=dotnet-ci


### PR DESCRIPTION
The dev branch will be deleted soon, and dotnet-docker-nightly only
needs CI for the master branch at this point.

cc: @mmitche @MichaelSimons