### PR TITLE
Adding release/1.1.0 corefx branch to CI

### DIFF
--- a/jobs/data/repolist.txt
+++ b/jobs/data/repolist.txt
@@ -40,6 +40,7 @@ dotnet/corefx branch=dev/cms_unix server=dotnet-ci
 dotnet/corefx branch=master server=dotnet-ci
 dotnet/corefx branch=release/1.0.0-rc2 server=dotnet-ci
 dotnet/corefx branch=release/1.0.0 server=dotnet-ci
+dotnet/corefx branch=release/1.1.0 server=dotnet-ci
 dotnet/corefxlab branch=master server=dotnet-ci
 dotnet/corert branch=master server=dotnet-ci
 dotnet/dotnet-docker-nightly branch=master server=dotnet-ci


### PR DESCRIPTION
cc: @mmitche 

Adding 1.1.0 release branch of corefx to the CI system