### PR TITLE
Add pre and post generation

### DIFF
--- a/jobs/generation/MetaGenerator.groovy
+++ b/jobs/generation/MetaGenerator.groovy
@@ -321,8 +321,12 @@ repos.each { repoInfo ->
 
             steps {
                 dsl {
-                    // Loads DSL groovy file
+                    // Loads the PreGen groovy file
+                    external("dotnet-ci/jobs/generation/PreGen.groovy")
+                    // Loads DSL groovy file from the repo
                     external(Utilities.getProjectName(repoInfo.project) + "/${repoInfo.definitionScript}")
+                    // Loads the PostGen groovy file
+                    external("dotnet-ci/jobs/generation/PostGen.groovy")
 
                     // Additional classpath should point to the utility repo
                     additionalClasspath('dotnet-ci')

--- a/jobs/generation/PostGen.groovy
+++ b/jobs/generation/PostGen.groovy
@@ -1,0 +1,4 @@
+// This file is invoked after the repo generator file is run
+// This file can be used to run post steps, like creating job reports or help jobs
+
+println("Running PostGen")

--- a/jobs/generation/PreGen.groovy
+++ b/jobs/generation/PreGen.groovy
@@ -1,0 +1,9 @@
+// This file is invoked before the repo generator file is run.
+// Within the same DSL step, the groovy files will see the same object model.
+// So code in this file can affect the code in the netci.groovy.  For instance,
+// this file could set a global indicating this is a pr test generation, which could
+// be used to to alter any number of options (for instance, altering triggers so that
+// generated jobs can be left un-disabled, but the default trigger options won't cause the
+// job to run for everyone.
+
+println("Running PreGen")


### PR DESCRIPTION
Run two additional groovy scripts.  PreGen.groovy goes before the netci.groovy execution, while PostGen.groovy goes after.  Since each groovy execution within the same DSL step shares the same state, Pre and Post gen can affect/be affected by the netci.grooy execution.