### PR TITLE
Update Utilities.groovy to include a machine affinity entry for VS15 Preview 4.

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -193,6 +193,8 @@ class Utilities {
                                 'latest-or-auto':'auto-win2012-20160824',
                                 // Win2012.R2 + VS2013.5 + VS2015.3 + VS15.P3
                                 'latest-or-auto-dev15':'auto-win2012-20160707',
+                                // Win2012.R2 + VS2013.5 + VS2015.3 + VS15.P4
+                                'latest-or-auto-dev15-preview4':'auto-win2012-20160912',
                                 // Dev15 image
                                 'latest-dev15':'auto-win2012-20160506',
                                 // For internal runs


### PR DESCRIPTION
FYI: @mmitche, @jaredpar, @jasonmalinowski, @Pilchie 

This image will support the Open Integration Framework Tests: https://github.com/dotnet/roslyn/pull/13732

We can move it to be post preview 4 whenever we are ready to make the switch for Roslyn as a whole.