### PR TITLE
Add corefx perf runs to dotnet-ci2

### DIFF
--- a/jobs/data/repolist.txt
+++ b/jobs/data/repolist.txt
@@ -107,3 +107,4 @@ Microsoft/PartsUnlimited branch=master server=dotnet-ci
 smile21prc/coreclr branch=coreclr-perf server=dotnet-ci2 definitionScript=perf.groovy
 dotnet/templating branch=master server=dotnet-ci
 john-soklaski/roslyn branch=benchview_integration server=dotnet-ci2 definitionScript=perf.groovy
+drewscoggins/corefx branch=master server=dotnet-ci2 definitionScript=perf.groovy subFolder=perf


### PR DESCRIPTION
Doing this on my fork first for testing and will change this over to
dotnet once I have it in good shape.