### PR TITLE
Adding dotnet-apiport to CI builds

### DIFF
--- a/jobs/data/repolist.txt
+++ b/jobs/data/repolist.txt
@@ -95,6 +95,7 @@ Microsoft/ChakraCore branch=release/1.2-ci server=dotnet-ci
 Microsoft/ChakraCore branch=release/1.3 server=dotnet-ci
 Microsoft/ChakraCore branch=release/1.3-ci server=dotnet-ci
 Microsoft/ConcordExtensibilitySamples branch=master server=dotnet-ci
+Microsoft/dotnet-apiport branch=master server=dotnet-ci
 Microsoft/MIEngine branch=master server=dotnet-ci
 Microsoft/msbuild branch=master server=dotnet-ci
 Microsoft/xunit-performance branch=master server=dotnet-ci


### PR DESCRIPTION
Add [dotnet-apiport](https://github.com/Microsoft/dotnet-apiport) to dotnet's CI builds.  The corresponding PR is in microsoft/dotnet-apiport#352

__Prerequisite Software__
* Visual Studio 2015 Community edition
    * msbuild
    * vstest.console.exe
* Powershell