### PR TITLE
Update Utilities.groovy to use a WinServer 2016 based image for VS15.P5

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -195,14 +195,14 @@ class Utilities {
                                 'latest-or-auto-dev15':'auto-win2012-20160707',
                                 // Win2012.R2 + VS2013.5 + VS2015.3 + VS15.P4
                                 'latest-or-auto-dev15-preview4':'auto-win2012-20160912',
-                                // Win2012.R2 + VS15.P5
-                                'latest-or-auto-dev15-preview5':'win2012-20161011-1',
+                                // Win2016 + VS15.P5
+                                'latest-or-auto-dev15-preview5':'win2016-20161013-1',
                                 // Dev15 image
                                 'latest-dev15':'auto-win2012-20160506',
                                 // For internal runs
                                 'latest-or-auto-internal':'windows-internal || auto-win2012-20160707-internal',
-                                // For internal runs - Win2012.R2 + VS15.P5
-                                'latest-or-auto-dev15-internal':'win2012-20161011-1-internal',
+                                // For internal runs - Win2016 + VS15.P5
+                                'latest-or-auto-dev15-internal':'win2016-20161013-1-internal',
                                 // For internal runs which don't need/want the static 'windows-internal' pool
                                 'latest-dev15-internal':'auto-win2012-20160707-internal',
                                 // For elevated runs


### PR DESCRIPTION
FYI. @mmitche 