### PR TITLE
Change Fedora 24 names to match other names

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -304,9 +304,9 @@ class Utilities {
                             'Fedora24' :
                                 [
                                 // Latest auto image.
-                                'latest':'fedora24-20161024',
+                                'latest-or-auto':'fedora24-20161024',
                                 // For outerloop runs
-                                'outer-latest':'fedora24-20161024-outer'
+                                'outer-latest-or-auto':'fedora24-20161024-outer'
                                 ],
                                 // Some nodes don't have git, which is what is required for the
                                 // generators.


### PR DESCRIPTION
corefx's netci.groovy expects these names to be of a particular format. Instead of special-casing this, or changing all the rest, I've just made these names the same as the other OS's.

@mmitche 