### PR TITLE
Disable shallow clone as this breaks CI for some scenarios

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -844,7 +844,6 @@ class Utilities {
                     extensions {
                         cloneOptions {
                             timeout(30)
-                            shallow(true)
                         }
                     }
                 }


### PR DESCRIPTION
Some projects use commit depth during CI.  Shallow clone breaks this