### PR TITLE
Add sbomer/linker to test netci changes for mono/linker

### DIFF
--- a/jobs/data/repolist.txt
+++ b/jobs/data/repolist.txt
@@ -109,3 +109,4 @@ drewscoggins/coreclr branch=coreclr-perf server=dotnet-ci2 definitionScript=perf
 dotnet/core branch=master server=dotnet-ci2
 dotnet/netcorecli-fsc branch=master server=dotnet-ci2
 mono/linker branch=master server=dotnet-ci2
+sbomer/linker branch=master server=dotnet-ci2


### PR DESCRIPTION
I'd like to enable ci for my fork so that I can make changes to netci.groovy (to debug the problem we're seeing with generated jobs not showing up), without creating noise in mono/linker.
Once we get the jobs working, I'll remove this repo from the repolist.

@mmitche 