### PR TITLE
Emit collapsed tables on `@dotnet-bot help`

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -1172,20 +1172,28 @@ The following is a list of valid commands on this PR.  To invoke a command, comm
 
 **The following commands are valid for all PRs and repositories.**
 
+<details>
+  <summary>Click to expand</summary>
+
 Comment Phrase | Action
 -------------- | ------
 @dotnet-bot test this please | Re-run all legs.  Use sparingly
 @dotnet-bot test ci please | Generates (but does not run) jobs based on changes to the groovy job definitions in this branch
 @dotnet-bot help | Print this help message
+</details>
 """
 
         if (defaultLegList != "") {
             helpMessage += """
 **The following jobs are launched by default for each PR against ${project}:${branchName}.**
 
+<details>
+  <summary>Click to expand</summary>
+
 Comment Phrase | Job Launched
 -------------- | ------------
 ${defaultLegList}
+</details>
 """
         }
 
@@ -1193,9 +1201,13 @@ ${defaultLegList}
             helpMessage += """
 **The following optional jobs are available in PRs against ${project}:${branchName}.**
 
+<details>
+  <summary>Click to expand</summary>
+
 Comment Phrase | Job Launched
 -------------- | ------------
 ${nonDefaultLegList}
+</details>
 """
         }
 


### PR DESCRIPTION
Currently, the help message displays a wall of content in tabular form.
This change transforms:

> The following is a list of valid commands on this PR.  To invoke a command, comment the indicated phrase on
the PR
> **The following commands are valid for all PRs and repositories.**
>
> Comment Phrase | Action
>-------------- | ------
>@dotnet-bot test this please | Re-run all legs.  Use sparingly
>@dotnet-bot test ci please | Generates (but does not run) jobs based on changes to the groovy job definitions in this branch
> @dotnet-bot help | Print this help message

to:

> The following is a list of valid commands on this PR.  To invoke a command, comment the indicated phrase on
the PR
>**The following commands are valid for all PRs and repositories.**
>
><details>
>  <summary>Click to expand</summary>
>
>Comment Phrase | Action
>-------------- | ------
>@dotnet-bot test this please | Re-run all legs.  Use sparingly
>@dotnet-bot test ci please | Generates (but does not run) jobs based on changes to the groovy job definitions in this branch
>@dotnet-bot help | Print this help message
></details>

(and so on..)

Note that this works in all non-Edge / non-IE browsers.

Refs:
* https://developer.microsoft.com/en-us/microsoft-edge/platform/status/detailssummary
* MicrosoftEdge/Status#480