### PR TITLE
Add cross check integration to Utilities.

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -1133,6 +1133,37 @@ class Utilities {
 
         return DefaultRefSpec;
     }
+    
+    // Adds cross integration to this repo
+    def static addCROSSCheck(def dslFactory, String project, String branch, boolean runByDefault = true) {
+        def crossJob = dslFactory.job(Utilities.getFullJobName(project, 'CROSS_check', true)) {
+            steps {
+                // Download the tool
+                batchFile("powershell -Command \"wget '%CROSS_SOURCE%' -OutFile cross-integration.zip\"")
+                // Unzip it
+                batchFile("powershell -Command \"Add-Type -Assembly 'System.IO.Compression.FileSystem'; [System.IO.Compression.ZipFile]::ExtractToDirectory('cross-integration.zip', 'cross-tool')\"")
+                def orgName = Utilities.getOrgName(project)
+                def repoName = Utilities.getProjectName(project)
+                batchFile("cd cross-tool && cross --organization ${orgName} --repository ${repoName} --token %UPDATE_TOKEN% --writecomments %ghprbPullId%")
+            }
+            
+            // Ensure credentials are bound
+            wrappers {
+                // SAAS URL
+                credentialsBinding {
+                    string('CROSS_SOURCE', 'cross-sas-url')
+                    string('UPDATE_TOKEN', 'cross-update-token')
+                }
+            }
+        }
+        
+        
+        // Cross tool currently works on Windows only
+        Utilities.setMachineAffinity(crossJob, 'Windows_NT', 'latest-or-auto')
+        Utilities.addPrivatePermissions(crossJob, ['Microsoft'])
+        Utilities.standardJobSetup(crossJob, project, true, "*/${branch}")
+        Utilities.addGithubPRTriggerForBranch(crossJob, branch, 'CROSS Check', '(?i).*test\\W+cross\\W+please.*', !runByDefault)
+    }
 
     // Emits a helper job.  This job prints a help message to the GitHub comments section
     // Should only be emitted if the system has "ignore comments from bot" enabled.  The job is triggered


### PR DESCRIPTION
To use, add the following at the bottom of the job definition file:

// Runs the CROSS check by default
Utilities.addCROSSCheck(this, project, branch)
// Runs the CROSS check only when '@dotnet-bot test cross please' is commented
Utilities.addCROSSCheck(this, project, branch, false /*runByDefault*/)