### PR TITLE
Add entries for rc2 images

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -206,12 +206,16 @@ class Utilities {
                                 // Win2016 + VS15.P5
                                 'latest-or-auto-dev15-preview5':'win2016-20161013-1',
                                 // Win2016 + VS15.RC2
+                                'latest-or-auto-dev15-rc2':'win2016-20170105',
+                                // Win2016 + VS15.RC3
                                 'latest-or-auto-dev15-rc':'win2016-20170113',
                                 // Dev15 image
                                 'latest-dev15':'auto-win2012-20160506',
                                 // For internal runs
                                 'latest-or-auto-internal':'auto-win2012-20160707-internal',
                                 // For internal runs - Win2016 + VS15.RC2
+                                'latest-or-auto-dev15-rc2-internal':'win2016-20170105-internal',
+                                // For internal runs - Win2016 + VS15.RC3
                                 'latest-or-auto-dev15-internal':'win2016-20170113-internal',
                                 // For internal runs which don't need/want the static 'windows-internal' pool
                                 'latest-dev15-internal':'auto-win2012-20160707-internal',


### PR DESCRIPTION
There seems to be an issue with RC3 image for some where the VsSdk.targets is not found.
Adding a legacy RC2 image, so that it can be used explicitly until the issue is resolved with RC3 images.