### PR TITLE
Added sdk builds

### DIFF
--- a/jobs/data/repolist.txt
+++ b/jobs/data/repolist.txt
@@ -79,6 +79,9 @@ dotnet/roslyn-analyzers branch=master server=dotnet-ci
 dotnet/roslyn-project-system branch=master server=dotnet-ci
 dotnet/roslyn-project-system branch=dev15-rc3 server=dotnet-ci
 dotnet/roslyn-project-system branch=post-dev15 server=dotnet-ci
+dotnet/sdk branch=master server=dotnet-ci
+dotnet/sdk branch=future server=dotnet-ci
+dotnet/sdk branch=dev15-rc3 server=dotnet-ci
 dotnet/interactive-window branch=master server=dotnet-ci
 dotnet/symreader branch=master server=dotnet-ci
 dotnet/symreader-portable branch=master server=dotnet-ci


### PR DESCRIPTION
Moving sdk from private to public generation. Dependent on a similar change in the internal version, and https://github.com/dotnet/sdk/pull/737.