### PR TITLE
Add flaky CMAKE failure to auto-retry list

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -550,7 +550,8 @@ class Utilities {
             'failed to mkdirs',
             'ERROR: Timeout after 10 minutes',
             'Slave went offline during the build',
-            '\'type_traits\' file not found' // This is here for certain flavors of clang on Ubuntu, which can exhibit odd errors.
+            '\'type_traits\' file not found', // This is here for certain flavors of clang on Ubuntu, which can exhibit odd errors.
+            'Only AMD64 and I386 are supported', // Appears to be a flaky CMAKE failure
             ]
         def regex = '(?i).*('
         regex += Utilities.joinStrings(expressionsToRetry, '|')


### PR DESCRIPTION
For "Only AMD64 and I386 are supported"