### PR TITLE
Move stability testing to perf-infra

### DIFF
--- a/jobs/data/repolist.txt
+++ b/jobs/data/repolist.txt
@@ -112,7 +112,7 @@ dotnet/core branch=master server=dotnet-ci2
 dotnet/netcorecli-fsc branch=master server=dotnet-ci2
 dotnet/netcorecli-fsc branch=rel/1.0.0-preview2.1 server=dotnet-ci2
 dotnet/netcorecli-fsc branch=rel/1.0.0-preview2 server=dotnet-ci2
-dotnet/citest branch=master server=dotnet-ci2 definitionScript=perf.groovy subFolder=stability
+dotnet/perf-infra branch=master server=dotnet-ci2 definitionScript=stability.groovy subFolder=stability
 mono/linker branch=master server=dotnet-ci2
 Microsoft/vstest branch=master server=dotnet-ci
 Microsoft/vstest branch=future server=dotnet-ci


### PR DESCRIPTION
We are moving the stability tests over to perf-infra and off of citest.
So I need to remove the entry we had for citest and add the entry for
perf-infra.