### PR TITLE
Move mono/linker to instance 1

### DIFF
--- a/jobs/data/repolist.txt
+++ b/jobs/data/repolist.txt
@@ -116,6 +116,6 @@ dotnet/netcorecli-fsc branch=master server=dotnet-ci2
 dotnet/netcorecli-fsc branch=rel/1.0.0-preview2.1 server=dotnet-ci2
 dotnet/netcorecli-fsc branch=rel/1.0.0-preview2 server=dotnet-ci2
 dotnet/perf-infra branch=master server=dotnet-ci2 definitionScript=stability.groovy subFolder=stability
-mono/linker branch=master server=dotnet-ci2
+mono/linker branch=master server=dotnet-ci
 Microsoft/vstest branch=master server=dotnet-ci
 Microsoft/vstest branch=future server=dotnet-ci


### PR DESCRIPTION
There seems to be some issue with updating commit statuses from server 2,