### PR TITLE
Replace usage of 'mac' with OS specific labels

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -177,12 +177,18 @@ class Utilities {
                                 ],
                             'OSX' :
                                 [
-                                // Generic version label
-                                '' : 'mac',
-                                // Latest auto image.
-                                'latest-or-auto':'mac',
-                                // For elevated runs
-                                'latest-or-auto-elevated':'mac-elevated'
+                                // 10.11 (El Capitan) image.
+                                '10.11':'osx-10.11',
+                                // 10.11 (El Capitan) image.
+                                '10.11-elevated':'osx-10.11-elevated',
+                                // 10.11 (El Capitan) image.
+                                '10.12':'osx-10.12',
+                                // 10.11 (El Capitan) image.
+                                '10.12-elevated':'osx-10.12-elevated',
+                                // Latest auto image.  For temporary backwards compatibility
+                                'latest-or-auto':'osx-10.11',
+                                // For elevated runs. For temporary backwards compatibility
+                                'latest-or-auto-elevated':'osx-10.11-elevated'
                                 ],
 
                             // This is Windows Server 2012 R2


### PR DESCRIPTION
Deprecate the mac label and replace it with osx-10.11 and osx-10.12.

This will be followed with:
* Remove latest-or-auto usage
* Remove mac labels from existing machines after verification