### PR TITLE
Official build view

### DIFF
--- a/jobs/generation/MetaGenerator.groovy
+++ b/jobs/generation/MetaGenerator.groovy
@@ -281,7 +281,7 @@ repos.each { repoInfo ->
                 name 'Job Statistics'
             }
 
-            def bottomPortlets = view / NodeBuilder.newInstance()
+            def bottomPortlets = view / NodeBuilder.newInstance().bottomPortlets {}
 
             bottomPortlets << 'hudson.plugins.view.dashboard.core.UnstableJobsPortlet' {
                 id createPortletId()

--- a/jobs/generation/MetaGenerator.groovy
+++ b/jobs/generation/MetaGenerator.groovy
@@ -34,14 +34,14 @@ class Repo {
     String utilitiesRepo
     // The branch for the utilities repo
     String utilitiesRepoBranch
-    
+
     // Lazily set up data
     // Branches that should be targeted for PRs against this job definition
-    String[] prTargetBranches 
+    String[] prTargetBranches
     // Branches that should be skipped for PRs against this job definition
-    String[] prSkipBranches 
-    
-    def Repo(String project, 
+    String[] prSkipBranches
+
+    def Repo(String project,
              String[] folders,
              String branch,
              String server,
@@ -59,7 +59,7 @@ class Repo {
         this.additionalPRBranches = additionalPRBranches
         this.utilitiesRepo = utilitiesRepo
         this.utilitiesRepoBranch = utilitiesRepoBranch
-    }    
+    }
 
     // Parse the input string and return a Repo object
     def static parseInputString(String input, def out) {
@@ -133,7 +133,7 @@ class Repo {
             }
             i++
         }
-        
+
         if (branch == null || branch == '') {
             out.println("Line '${input}' invalid")
             out.println("branch must be specified")
@@ -144,17 +144,17 @@ class Repo {
             out.println("server must be specified")
             assert false
         }
-        
+
         folders = [Utilities.getFolderName(project)]
-        
+
         // If they asked for subfolders, add them
         if (subFolders != null) {
             folders += subFolders
         }
-        
+
         // Add the branch after
         folders += Utilities.getFolderName(branch)
-        
+
         // Construct a new object and return
         return new Repo(project, folders, branch, server, definitionScript, isDefaultPRBranch, additionalPRBranches, utilitiesRepo, utilitiesRepoBranch)
     }
@@ -181,17 +181,17 @@ streamFileFromWorkspace(RepoListLocation).eachLine { line ->
 // and the PR skip branches
 
 repos.each { repoInfo ->
-    def otherRepos = repos.findAll { searchRepoInfo -> 
+    def otherRepos = repos.findAll { searchRepoInfo ->
         // Same project
         searchRepoInfo.project == repoInfo.project &&
         // Different branch
         searchRepoInfo.branch != repoInfo.branch
     }
-    
+
     // Consistency check
     // Find other projects that have the same project, same branch, and same definition script
-    
-    assert repos.find { searchRepoInfo -> 
+
+    assert repos.find { searchRepoInfo ->
         // Not the exact same item
         repoInfo != searchRepoInfo &&
         // Same project
@@ -202,10 +202,10 @@ repos.each { repoInfo ->
         // based on glob syntax.  But it should prevent most errors.
         searchRepoInfo.definitionScript == repoInfo.definitionScript
     } == null
-    
+
     repoInfo.prTargetBranches = []
     repoInfo.prSkipBranches = []
-    
+
     // Determine the prTargetBranches and prSkipBranches
     if (repoInfo.isDefaultPRBranch) {
         repoInfo.prTargetBranches = ['.*']


### PR DESCRIPTION
This PR creates a view in the root folder of each project, giving a full view of the health of the project. It includes all non-pr builds (determined by regex for everything not ending in `prtest`). It also includes job build and run statistics, test statistics, and test trends. For an example of what this will look like, see https://ci.dot.net/job/dotnet_roslyn/view/Official%20Builds/, where I've manually created a view that looks like what we'll see after merge. I've tested the view configuration on a private Jenkins server, so it should compile and run correctly. Provided we're satisfied with this view, I'll port it over to the internal repo as well. Tagging @mmitche @tannergooding @jaredpar @dotnet/roslyn-infrastructure.