### PR TITLE
Factors out the view creation

### DIFF
--- a/jobs/generation/MetaGenerator.groovy
+++ b/jobs/generation/MetaGenerator.groovy
@@ -229,16 +229,18 @@ repos.each { repoInfo ->
 
     // Make the folders. Save the root folder for overview generation
     def generatorFolder = ''
+    def projectName = ''
     for (folderElement in repoInfo.folders) {
         if (generatorFolder == '') {
             generatorFolder = folderElement
+            projectName = folderElement
         }
         else {
             // Append a new folder
             generatorFolder += "/${folderElement}"
         }
         folder(generatorFolder) {}
-        registerFolderView(generatorFolder)
+        registerFolderView(generatorFolder, projectName)
     }
 
     // Make the PR test folder

--- a/jobs/generation/MetaGenerator.groovy
+++ b/jobs/generation/MetaGenerator.groovy
@@ -229,73 +229,16 @@ repos.each { repoInfo ->
 
     // Make the folders. Save the root folder for overview generation
     def generatorFolder = ''
-    def projectFolder = ''
     for (folderElement in repoInfo.folders) {
         if (generatorFolder == '') {
             generatorFolder = folderElement
-            projectFolder = folderElement
         }
         else {
             // Append a new folder
             generatorFolder += "/${folderElement}"
         }
         folder(generatorFolder) {}
-    }
-
-    // Create a view for all jobs in this folder that don't end with prtest
-    dashboardView("${projectFolder}/Official Builds") {
-        recurse()
-        jobs {
-            regex(/.*(?<!prtest)$/)
-        }
-        statusFilter(StatusFilter.ENABLED)
-
-        columns {
-            status()
-            weather()
-            name()
-            lastSuccess()
-            lastFailure()
-            lastDuration()
-        }
-
-        topPortlets {
-            jenkinsJobsList {
-                defaultName = "${projectFolder} jobs"
-            }
-        }
-
-        rightPortlets {
-            buildStatistics {
-                displayName 'Build Statistics'
-            }
-        }
-
-        def createPortletId = {
-            def random = new Random()
-            return "dashboard_portlet_${random.nextInt(32000)}"
-        }
-
-        configure { view ->
-            view / 'leftPortlets' / 'hudson.plugins.view.dashboard.stats.StatJobs' {
-                id createPortletId()
-                name 'Job Statistics'
-            }
-
-            def bottomPortlets = view / NodeBuilder.newInstance().bottomPortlets {}
-
-            bottomPortlets << 'hudson.plugins.view.dashboard.core.UnstableJobsPortlet' {
-                id createPortletId()
-                name 'Unstable Jobs'
-                showOnlyFailedJobs 'false'
-                recurse 'true'
-            }
-            bottomPortlets << 'hudson.plugins.view.dashboard.test.TestStatisticsPortlet' {
-                id createPortletId()
-                name 'Test Statistics'
-                hideZeroTestProjects 'true'
-            }
-        }
+        registerFolderView(generatorFolder)
     }
 
     // Make the PR test folder

--- a/jobs/generation/MetaGenerator.groovy
+++ b/jobs/generation/MetaGenerator.groovy
@@ -220,6 +220,7 @@ repos.each { repoInfo ->
 }
 
 // Now that we have all the repos, generate the jobs
+def dslFactory = this
 repos.each { repoInfo ->
 
     // Determine whether we should skip this repo becuase it resides on a different server
@@ -240,7 +241,7 @@ repos.each { repoInfo ->
             generatorFolder += "/${folderElement}"
         }
         folder(generatorFolder) {}
-        registerFolderView(generatorFolder, projectName)
+        addStandardFolderView(dslFactory, generatorFolder, projectName)
     }
 
     // Make the PR test folder

--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -1276,16 +1276,17 @@ class Utilities {
     /**
      * Creates the standard job view for a given folder. This does not create the folder.
      *
+     * @param dslFactory The factory that is creating the view. In your primary groovy definitions, the parameter is 'this'
      * @param folderName The folder to create a view for.
      * @param jobName The name of the job, to use in customizing text. Defaults to folderName if not specified.
      * @param viewName The name to give the standard view. Defaults to 'Official Builds'.
      * @param filterRegex The regex that determines what jobs should display in the view.
      * @return The created view
      */
-    def static registerFolderView(String folderName, String jobName = null, String viewName = 'Official Builds', String filterRegex = /.*(?<!prtest)$/) {
+    def static addStandardFolderView(def dslFactory, String folderName, String jobName = null, String viewName = 'Official Builds', String filterRegex = /.*(?<!prtest)$/) {
         jobName = jobName ?: folderName
         // Create a view for all jobs in this folder that don't end with prtest
-        return dashboardView("${folderName}/${viewName}") {
+        return dslFactory.dashboardView("${folderName}/${viewName}") {
             recurse()
             jobs {
                 regex(filterRegex)


### PR DESCRIPTION
This factors out view creation so that it can be used by other scripts, and moves view creation such that every public folder created by the metagenerator gets a view. Tagging @mmitche FYI @dotnet/roslyn-infrastructure.