### PR TITLE
Allow restriction to non-DTAP machines

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -367,7 +367,7 @@ class Utilities {
                             'Generators' :
                                 [
                                 '' : '!windowsnano16',
-                                'latest-or-auto':'!windowsnano16 && !performance'
+                                'latest-or-auto':'!windowsnano16 && !performance && !dtap'
                                 ]
                             ]
         def versionLabelMap = machineMap.get(osName, null)


### PR DESCRIPTION
Allow restriction of generation to non-dtap.  No machines are currently labeled DTAP.