### PR TITLE
Use automatically generated DSL from newest notification plugin

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -1200,14 +1200,24 @@ class Utilities {
      * Each call to this overwrites the previous set of notifications
      *
      * @param job Job to add hook to
-     * @param endPoints List of credential IDs of the endpoints to run
+     * @param targetEndpoints List of credential IDs of the endpoints to run
      */
-    private static void setBuildEventWebHooks(def job, def endPoints) {
+    private static void setBuildEventWebHooks(def job, def targetEndpoints) {
         job.with {
-            notifications {
-                endPoints.each { endPoint ->
-                    endpoint(endPoint) {
-                        event('all')
+            properties {
+                hudsonNotificationProperty {
+                    endpoints {
+                        targetEndpoints.each { targetEndpoint ->
+                            // Use the secret endpoint to source the endpoint URL from credentials
+                            endpoint {
+                                urlInfo {
+                                    urlType('SECRET')
+                                    urlOrId(targetEndpoint)
+                                }
+                                event('all')
+                                retries(3)
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Formalizes public/private URLs, adds pipeline support.

This must be merged after an update of the notification-plugin: https://github.com/mmitche/notification-plugin/tree/private-urls