### PR TITLE
Update Fedora 24 images. Includes the "requests" python module.

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -353,9 +353,9 @@ class Utilities {
                             'Fedora24' :
                                 [
                                 // Latest auto image.
-                                'latest-or-auto':'fedora24-20161024',
+                                'latest-or-auto':'fedora24-20170420',
                                 // For outerloop runs
-                                'outer-latest-or-auto':'fedora24-20161024-outer'
+                                'outer-latest-or-auto':'fedora24-20170420-outer'
                                 ],
                             'Tizen' :
                                 [

--- a/management/nodes/Capture-VM.ps1
+++ b/management/nodes/Capture-VM.ps1
@@ -12,7 +12,7 @@
 #>
 
 param (
-    [ValidateSet('ubuntu1404','ubuntu1504', 'ubuntu1604', 'ubuntu1610', 'win2008', 'win2012', 'win2016', 'centos71', 'rhel72', 'freebsd', 'suse132', 'suse421', 'deb82', 'fedora23', 'deb84')]
+    [ValidateSet('ubuntu1404','ubuntu1504', 'ubuntu1604', 'ubuntu1610', 'win2008', 'win2012', 'win2016', 'centos71', 'rhel72', 'freebsd', 'suse132', 'suse421', 'deb82', 'fedora23', 'fedora24', 'deb84')]
     [string]$ImageBaseName = $(Read-Host -prompt "VM image base name of image to capture."),
     [string]$ResourceGroupName = $null,
     [string]$VMName = $(Read-Host -prompt "VM name to capture"),

--- a/management/nodes/Images.csv
+++ b/management/nodes/Images.csv
@@ -17,6 +17,8 @@ fedora23-20160622,auto-fedora23-20160622,Linux,system,Microsoft.Compute/Images/d
 fedora23-20160622-outer,auto-fedora23-20160622outer,Linux,system,Microsoft.Compute/Images/dotnetci/fedora23-20160622.vhd,All,./startupScripts/fedora23-20160622-outer.sh,/mnt/resource/j
 fedora24-20161024,fedora24-20161024,Linux,system,Microsoft.Compute/Images/dotnetci/fedora24-20161024.vhd,All,./startupScripts/fedora24-20161024.sh,/mnt/resource/j
 fedora24-20161024-outer,fedora24-20161024-outer,Linux,system,Microsoft.Compute/Images/dotnetci/fedora24-20161024.vhd,All,./startupScripts/fedora24-20161024-outer.sh,/mnt/resource/j
+fedora24-20170420,fedora24-20170420,Linux,system,Microsoft.Compute/Images/dotnetci/fedora24-20170420-osDisk.721d7e12-5209-418c-a5a4-3b268cdd320c.vhd,All,./startupScripts/fedora24-20170420.sh,/mnt/resource/j
+fedora24-20170420-outer,fedora24-20170420-outer,Linux,system,Microsoft.Compute/Images/dotnetci/fedora24-20170420-osDisk.721d7e12-5209-418c-a5a4-3b268cdd320c.vhd,All,./startupScripts/fedora24-20170420-outer.sh,/mnt/resource/j
 freebsd-20161026,freebsd-20161026,Linux,system,Microsoft.Compute/Images/dotnetci/freebsd-20161026-osDisk.d9e2d372-a805-4676-867e-ce35b6438ae2.vhd,All,./startupScripts/freebsd-20161025.sh,/mnt/resource/j
 rhel72-20160211,auto-rhel72-20160211,Linux,system,Microsoft.Compute/Images/dotnetci/rhel72-20160211.vhd,All,./startupScripts/rhel72-20160211.sh,/mnt/resource/j
 rhel72-20160412-1-outer,auto-rhel72-20160412.1outer,Linux,system,Microsoft.Compute/Images/dotnetci/rhel72-20160412-1.vhd,All,./startupScripts/rhel72-20160412-1-outer.sh,/mnt/resource/j

--- a/management/nodes/startupScripts/fedora24-20170420-outer.sh
+++ b/management/nodes/startupScripts/fedora24-20170420-outer.sh
@@ -1,0 +1,8 @@
+# Make the /mnt folder writeable
+chmod 777 /mnt/resource
+
+# Make dotnet-bot sudo not prompt for passwords
+bash -c 'echo "dotnet-bot ALL=NOPASSWD: ALL" | (EDITOR="tee -a" visudo)'
+
+# Remove the file that allows dotnet-bot paswordless, nointeractive sudoing (since we are done sudoing now).
+rm /etc/sudoers.d/zzz-dotnet-bot

--- a/management/nodes/startupScripts/fedora24-20170420.sh
+++ b/management/nodes/startupScripts/fedora24-20170420.sh
@@ -1,0 +1,5 @@
+# Make the /mnt/resource folder writeable
+chmod -R 777 /mnt/resource/
+
+# Remove the file that allows dotnet-bot paswordless, nointeractive sudoing (since we are done sudoing now).
+rm /etc/sudoers.d/zzz-dotnet-bot


### PR DESCRIPTION
@mmitche 

Fedora 24 wasn't in the "ValidateSet" for Capture-VM.ps1, so I added it.