### PR TITLE
Add CoreCLR branch dev/local-gc to CI

### DIFF
--- a/jobs/data/repolist.txt
+++ b/jobs/data/repolist.txt
@@ -45,6 +45,7 @@ dotnet/coreclr branch=release/1.0.0 server=dotnet-ci
 dotnet/coreclr branch=release/1.1.0 server=dotnet-ci
 dotnet/coreclr branch=release/2.0.0 server=dotnet-ci
 dotnet/coreclr branch=dev/unix_test_workflow server=dotnet-ci
+dotnet/coreclr branch=dev/local-gc server=dotnet-ci
 dotnet/corefx branch=master server=dotnet-ci
 dotnet/corefx branch=release/1.0.0 server=dotnet-ci
 dotnet/corefx branch=release/1.1.0 server=dotnet-ci


### PR DESCRIPTION
This feature branch has a `netci.groovy` that should be running a substantially reduced set of jobs to avoid stressing the CI: https://github.com/dotnet/coreclr/compare/dev/local-gc . cc @Maoni0 @sergiy-k @adityamandaleeka . @mmitche is this OK?