### PR TITLE
Add release/2.0.0 branch to perf runs

### DIFF
--- a/jobs/data/repolist.txt
+++ b/jobs/data/repolist.txt
@@ -41,6 +41,7 @@ dotnet/core-setup branch=release/2.0.0 server=dotnet-ci
 dotnet/codeformatter branch=master server=dotnet-ci2
 dotnet/coreclr branch=master server=dotnet-ci
 dotnet/coreclr branch=master server=dotnet-ci2 definitionScript=perf.groovy subFolder=perf
+dotnet/coreclr branch=release/2.0.0 server=dotnet-ci2 definitionScript=perf.groovy subFolder=perf
 jorive/coreclr branch=dev/baseline-with-new-api server=dotnet-ci2 definitionScript=perf.groovy subFolder=perf
 dotnet/coreclr branch=release/1.0.0 server=dotnet-ci
 dotnet/coreclr branch=release/1.1.0 server=dotnet-ci
@@ -52,6 +53,7 @@ dotnet/corefx branch=release/1.0.0 server=dotnet-ci
 dotnet/corefx branch=release/1.1.0 server=dotnet-ci
 dotnet/corefx branch=release/2.0.0 server=dotnet-ci
 dotnet/corefx branch=master server=dotnet-ci2 definitionScript=perf.groovy subFolder=perf
+dotnet/corefx branch=release/2.0.0 server=dotnet-ci2 definitionScript=perf.groovy subFolder=perf
 dotnet/corefx branch=master server=dotnet-ci3 definitionScript=pipelinejobs.groovy utilitiesRepoBranch=dev/pipelinesupport
 dotnet/corefxlab branch=master server=dotnet-ci
 dotnet/corert branch=master server=dotnet-ci


### PR DESCRIPTION
This turns on performance runs for both CoreFX and CoreCLR on the
release/2.0.0 branches.