### PR TITLE
Bump RHEL images to pick up LLVM with PGO fix

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -317,9 +317,9 @@ class Utilities {
                                 ],
                             'RHEL7.2' :
                                 [
-                                '' : 'auto-rhel72-20160211',
+                                '' : 'auto-rhel72-20170525',
                                 // Latest auto image.
-                                'latest-or-auto':'auto-rhel72-20160211',
+                                'latest-or-auto':'auto-rhel72-20170525',
                                 // For outerloop runs.
                                 'outer-latest-or-auto':'auto-rhel72-20160412.1outer'
                                 ],

--- a/management/nodes/Images.csv
+++ b/management/nodes/Images.csv
@@ -22,6 +22,7 @@ fedora24-20170420-outer,fedora24-20170420-outer,Linux,system,Microsoft.Compute/I
 freebsd-20161026,freebsd-20161026,Linux,system,Microsoft.Compute/Images/dotnetci/freebsd-20161026-osDisk.d9e2d372-a805-4676-867e-ce35b6438ae2.vhd,All,./startupScripts/freebsd-20161025.sh,/mnt/resource/j
 rhel72-20160211,auto-rhel72-20160211,Linux,system,Microsoft.Compute/Images/dotnetci/rhel72-20160211.vhd,All,./startupScripts/rhel72-20160211.sh,/mnt/resource/j
 rhel72-20160412-1-outer,auto-rhel72-20160412.1outer,Linux,system,Microsoft.Compute/Images/dotnetci/rhel72-20160412-1.vhd,All,./startupScripts/rhel72-20160412-1-outer.sh,/mnt/resource/j
+rhel72-20170525,auto-rhel72-20170525,Linux,system,Microsoft.Compute/Images/dotnetci/rhel72-20170525-osDisk.3c9a878a-1198-4121-ae45-525c22fc9b49.vhd,All,./startupScripts/rhel72-20170525.sh,/mnt/resource/j
 suse132-20160315,auto-suse132-20160315,Linux,system,Microsoft.Compute/Images/dotnetci/suse132-20160315.vhd,All,./startupScripts/suse132-20160315.sh,/mnt/resource/j
 suse132-20160315-outer,auto-suse132-20160315outer,Linux,system,Microsoft.Compute/Images/dotnetci/suse132-20160315.vhd,All,./startupScripts/suse132-20160315-outer.sh,/mnt/resource/j
 suse421-20160920,auto-suse421-20160920,Linux,system,Microsoft.Compute/Images/dotnetci/suse421-20160920.vhd,All,./startupScripts/suse421-20160920.sh,/mnt/resource/j

--- a/management/nodes/startupScripts/rhel72-20170525.sh
+++ b/management/nodes/startupScripts/rhel72-20170525.sh
@@ -1,0 +1,5 @@
+# Create the workspace and make it writeable
+chmod 777 /mnt/resource/
+
+# Remove the file that allows dotnet-bot paswordless, nointeractive sudoing (since we are done sudoing now).
+rm /etc/sudoers.d/zzz-dotnet-bot


### PR DESCRIPTION
This will use the new images for RHEL inner loop jobs.  I will follow up with a PR to update the outerloop images tomorrow.

I've already added clouds to both ci and ci2 with the new labels, so things should just work, but if something goes sideways, please revert this commit.