### PR TITLE
Add a manual trigger option

### DIFF
--- a/src/jobs/generation/JobReport.groovy
+++ b/src/jobs/generation/JobReport.groovy
@@ -92,6 +92,10 @@ class JobReport {
         addReference(jobName)
     }
 
+    def addManuallyTriggeredJob(String jobName) {
+        addReference(jobName)
+    }
+
     def addPRTriggeredJob(String jobName, String[] targetBranches, String context, String triggerPhrase, boolean isDefault) {
 
         def simplifiedTriggerPhraseString = triggerPhrase

--- a/src/org/dotnet/ci/pipelines/Pipeline.groovy
+++ b/src/org/dotnet/ci/pipelines/Pipeline.groovy
@@ -328,7 +328,7 @@ class Pipeline {
         return triggerPipelineOnEvent(builder, parameters)
     }
 
-    /* Creates a Triggers a pipeline that only triggers manually
+    /* Creates a pipeline that only triggers manually
      * 
      * @param parameters Parameters to pass to the pipeline
      *

--- a/src/org/dotnet/ci/pipelines/Pipeline.groovy
+++ b/src/org/dotnet/ci/pipelines/Pipeline.groovy
@@ -326,6 +326,19 @@ class Pipeline {
         return triggerPipelineOnEvent(builder, parameters)
     }
 
+    /* Creates a Triggers a pipeline that only triggers manually
+     * 
+     * @param parameters Parameters to pass to the pipeline
+     *
+     * @return Newly created job
+     */
+    public def triggerPipelineManually(Map<String,Object> parameters = [:]) {
+        GenericTriggerBuilder builder = GenericTriggerBuilder.triggerManually()
+
+        // Call the generic API
+        return triggerPipelineOnEvent(builder, parameters)
+    }
+
     // Creates a pipeline job for a generic trigger event
     // Parameters:
     //  triggerBuilder - Trigger that the pipeline should run on

--- a/src/org/dotnet/ci/triggers/GenericTriggerBuilder.groovy
+++ b/src/org/dotnet/ci/triggers/GenericTriggerBuilder.groovy
@@ -74,7 +74,7 @@ class GenericTriggerBuilder implements TriggerBuilder {
             JobReport.Report.addCronTriggeredJob(job.name, this._cronString, this._alwaysRun)
         }
         else {
-            JobReport.Report.addManuallyTriggered(job.name)
+            JobReport.Report.addManuallyTriggeredJob(job.name)
         }
     }
 }

--- a/src/org/dotnet/ci/triggers/GenericTriggerBuilder.groovy
+++ b/src/org/dotnet/ci/triggers/GenericTriggerBuilder.groovy
@@ -7,7 +7,8 @@ import jobs.generation.Utilities
 // Periodic - Periodic triggers against a Git repo
 class GenericTriggerBuilder implements TriggerBuilder {
     public enum TriggerType {
-        PERIODIC
+        PERIODIC,
+        MANUAL
     }
 
     // Periodic
@@ -27,14 +28,23 @@ class GenericTriggerBuilder implements TriggerBuilder {
         this._triggerType = triggerType
     }
 
-    // Constructs a new periodic trigger
-    // Parameters:
-    //  cronString - Cron string to run the job on
-    // Returns:
-    //  a new periodic trigger that runs on the specified interval
+    /* Constructs a new periodic trigger
+     * 
+     * @param cronString Cron string to run the job on
+     * @return New periodic trigger that runs on the specified interval
+     */
     def static GenericTriggerBuilder triggerPeriodically(String cronString) {
         def newTrigger = new GenericTriggerBuilder(TriggerType.PERIODIC)
         newTrigger._cronString = cronString
+        return newTrigger
+    }
+
+    /* Constructs a new manual trigger.  This effecitvley means no trigger
+     * 
+     * @return New manual trigger
+     */
+    def static GenericTriggerBuilder triggerManually() {
+        def newTrigger = new GenericTriggerBuilder(TriggerType.MANUAL)
         return newTrigger
     }
     

--- a/src/org/dotnet/ci/triggers/GenericTriggerBuilder.groovy
+++ b/src/org/dotnet/ci/triggers/GenericTriggerBuilder.groovy
@@ -58,7 +58,7 @@ class GenericTriggerBuilder implements TriggerBuilder {
     // Parameters:
     //  job - Job to emit trigger for
     void emitTrigger(def job) {
-        assert this._triggerType == TriggerType.PERIODIC
+        assert (this._triggerType == TriggerType.PERIODIC) || (this._triggerType == TriggerType.MANUAL)
 
         job.with {
             triggers {

--- a/src/org/dotnet/ci/triggers/GenericTriggerBuilder.groovy
+++ b/src/org/dotnet/ci/triggers/GenericTriggerBuilder.groovy
@@ -60,17 +60,21 @@ class GenericTriggerBuilder implements TriggerBuilder {
     void emitTrigger(def job) {
         assert (this._triggerType == TriggerType.PERIODIC) || (this._triggerType == TriggerType.MANUAL)
 
-        job.with {
-            triggers {
-                if (this._alwaysRun) {
-                    cron(this._cronString)
-                }
-                else {
-                    scm(this._cronString)
+        if (this._triggerType == TriggerType.PERIODIC) {
+            job.with {
+                triggers {
+                    if (this._alwaysRun) {
+                        cron(this._cronString)
+                    }
+                    else {
+                        scm(this._cronString)
+                    }
                 }
             }
+            JobReport.Report.addCronTriggeredJob(job.name, this._cronString, this._alwaysRun)
         }
-
-        JobReport.Report.addCronTriggeredJob(job.name, this._cronString, this._alwaysRun)
+        else {
+            JobReport.Report.addManuallyTriggered(job.name)
+        }
     }
 }

--- a/src/org/dotnet/ci/triggers/GenericTriggerBuilder.groovy
+++ b/src/org/dotnet/ci/triggers/GenericTriggerBuilder.groovy
@@ -5,6 +5,7 @@ import jobs.generation.Utilities
 
 // Covers a generic triggers in Jenkins
 // Periodic - Periodic triggers against a Git repo
+// Manual - No automatic trigger (or triggered manually)
 class GenericTriggerBuilder implements TriggerBuilder {
     public enum TriggerType {
         PERIODIC,
@@ -39,7 +40,7 @@ class GenericTriggerBuilder implements TriggerBuilder {
         return newTrigger
     }
 
-    /* Constructs a new manual trigger.  This effecitvley means no trigger
+    /* Constructs a new manual trigger.  This effectivley means no trigger
      * 
      * @return New manual trigger
      */
@@ -73,8 +74,11 @@ class GenericTriggerBuilder implements TriggerBuilder {
             }
             JobReport.Report.addCronTriggeredJob(job.name, this._cronString, this._alwaysRun)
         }
-        else {
+        else if (this._triggerType == TriggerType.MANUAL) {
             JobReport.Report.addManuallyTriggeredJob(job.name)
+        }
+        else {
+            assert false : "Unknown trigger type"
         }
     }
 }

--- a/tests/dsl/pipeline_manual_trigger.groovy
+++ b/tests/dsl/pipeline_manual_trigger.groovy
@@ -1,0 +1,6 @@
+import org.dotnet.ci.pipelines.Pipeline
+
+// Tests creation of a pipeline that triggers on pushes with non-string parameter types
+def newPipeline = Pipeline.createPipeline(this, 'simple_periodic.groovy')
+
+newPipeline.triggerPipelineManually(['Hello':false])


### PR DESCRIPTION
Adds the ability to create a pipeline that is only manually triggered.  This isn't so much a trigger as just a way of creating the job.  Jobs are created on the trigger call, so this allows for a job that isn't triggered from outside of a manual action.