### PR TITLE
Clone repo using an auth token

### DIFF
--- a/src/org/dotnet/ci/pipelines/Pipeline.groovy
+++ b/src/org/dotnet/ci/pipelines/Pipeline.groovy
@@ -135,8 +135,10 @@ class Pipeline {
         String baseJobName = getDefaultPipelineJobBaseName(pipelineFile)
         def newPipeline = new Pipeline(context, baseJobName, pipelineFile)
 
-        // Create a new source control for the basic setup here
-        def scm = new GithubPipelineScm(project, branch)
+        // Create a new source control for the basic setup here.
+        // By default today we're using the r/o PAT that identifies the cloner as dotnet-bot
+        // to avoid API rate limit issues when cloning the pipeline script, which happens on the master.
+        def scm = new GithubPipelineScm(project, branch, 'dotnet-bot-readonly-public-clone-token')
         newPipeline.setSourceControl(scm)
         return newPipeline
     }

--- a/src/org/dotnet/ci/pipelines/scm/GithubPipelineScm.groovy
+++ b/src/org/dotnet/ci/pipelines/scm/GithubPipelineScm.groovy
@@ -97,6 +97,10 @@ class GithubPipelineScm implements PipelineScm {
                         git {
                             remote {
                                 github(this._project)
+
+                                if (this._credentialsId != null) {
+                                    credentials(this._credentialsId)
+                                }
                             }
 
                             branch('${GitBranchOrCommit}')

--- a/src/org/dotnet/ci/pipelines/scm/GithubPipelineScm.groovy
+++ b/src/org/dotnet/ci/pipelines/scm/GithubPipelineScm.groovy
@@ -7,7 +7,7 @@ class GithubPipelineScm implements PipelineScm {
     private String _branch
     private String _credentialsId
 
-    public GitHubPipelineScm(String project, String branch, String credentialsId) {
+    public GithubPipelineScm(String project, String branch, String credentialsId) {
         _project = project
         _branch = branch
         _credentialsId = credentialsId

--- a/src/org/dotnet/ci/pipelines/scm/GithubPipelineScm.groovy
+++ b/src/org/dotnet/ci/pipelines/scm/GithubPipelineScm.groovy
@@ -7,6 +7,12 @@ class GithubPipelineScm implements PipelineScm {
     private String _branch
     private String _credentialsId
 
+    public GitHubPipelineScm(String project, String branch, String credentialsId) {
+        _project = project
+        _branch = branch
+        _credentialsId = credentialsId
+    }
+
     public GithubPipelineScm(String project, String branch) {
         _project = project
         _branch = branch


### PR DESCRIPTION
This sets the GitHub cloning to use an auth token.  The token is just a simple R/O public repo token (no selected scopes), but serves the identify the cloner.  This is useful to avoid rate limiting issues that might be propping up because of pipelines