### PR TITLE
Fix waitForHelixRuns ignoring work item failures

### DIFF
--- a/tests/pipeline/pipeline-tests.groovy
+++ b/tests/pipeline/pipeline-tests.groovy
@@ -185,18 +185,18 @@ stage ('Run Tests') {
                                     </HelixWorkItem>
                                 </ItemGroup>
                                 <PropertyGroup>
-                                    <CloudDropConnectionString>DefaultEndpointsProtocol=https;AccountName=$(CloudDropAccountName);AccountKey=$(CloudDropAccessToken);EndpointSuffix=core.windows.net</CloudDropConnectionString>
-                                    <CloudResultsConnectionString>DefaultEndpointsProtocol=https;AccountName=$(CloudResultsAccountName);AccountKey=$(CloudResultsAccessToken);EndpointSuffix=core.windows.net</CloudResultsConnectionString>
+                                    <CloudDropConnectionString>DefaultEndpointsProtocol=https;AccountName=\$(CloudDropAccountName);AccountKey=\$(CloudDropAccessToken);EndpointSuffix=core.windows.net</CloudDropConnectionString>
+                                    <CloudResultsConnectionString>DefaultEndpointsProtocol=https;AccountName=\$(CloudResultsAccountName);AccountKey=\$(CloudResultsAccessToken);EndpointSuffix=core.windows.net</CloudResultsConnectionString>
                                     <HelixApiEndpoint>https://helix.dot.net/api/2017-04-14/jobs</HelixApiEndpoint>
                                     <HelixJobType>test/functional/dotnet-ci</HelixJobType>
                                     <HelixSource>${helixSource}</HelixSource>
                                     <BuildMoniker>${helixBuild}</BuildMoniker>
                                     <HelixCreator>${helixCreator}</HelixCreator>
                                     <TargetQueues>Windows.10.Amd64.Open</TargetQueues>
-                                    <HelixLogFolder>$(MSBuildThisFileDirectory)</HelixLogFolder>
+                                    <HelixLogFolder>\$(MSBuildThisFileDirectory)</HelixLogFolder>
                                     <HelixCorrelationInfoFileName>job-info.json</HelixCorrelationInfoFileName>
                                     <HelixJobProperties>{ "operatingSystem": "pizza" }</HelixJobProperties>
-                                    <ArchivesRoot>$(MSBuildThisFileDirectory)</ArchivesRoot>
+                                    <ArchivesRoot>\$(MSBuildThisFileDirectory)</ArchivesRoot>
                                 </PropertyGroup
                                 <Target Name="Build" DependsOnTargets="HelixCloudBuild"/>
                             </Project>

--- a/tests/pipeline/pipeline-tests.groovy
+++ b/tests/pipeline/pipeline-tests.groovy
@@ -151,6 +151,78 @@ stage ('Run Tests') {
                 String url = library(libraryName).jobs.generation.Utilities.calculateGitHubURL('foo/bar')
                 assert url == 'https://github.com/foo/bar' : "Incorrect url for github URL"
             },
+
+            "vars - waitforHelixRuns - passed work item" : {
+                simpleNode('Windows_NT', 'latest') {
+                    dir('workItem') {
+                        writeFile file: 'run.cmd', text: """
+                        echo Passing
+                        exit /b 0
+                        """
+                    }
+                    zip zipFile: 'workItem.zip', dir: 'workItem'
+
+                    def helixSource = getHelixSource()
+                    // Ask the CI SDK for a Build that makes sense.  We currently use the hash for the build
+                    def helixBuild = getCommit()
+                    // Get the user that should be associated with the submission
+                    def helixCreator = getUser()
+
+                    dir("corefx") {
+                        git 'https://github.com/dotnet/corefx'
+                        bat 'init-tools.cmd'
+
+                        dir('test') {
+                            def fileContent = """
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="../Tools/CloudTest.Helix.targets"/>
+    <ItemGroup>
+        <HelixWorkItem Include="../../workItem.zip">
+            <Command>run.cmd</Command>
+            <PayloadFile>%(Identity)</PayloadFile>
+            <WorkItemId>The Work Item</WorkItemId>
+            <TimeoutInSeconds>10</TimeoutInSeconds>
+        </HelixWorkItem>
+    </ItemGroup>
+    <PropertyGroup>
+        <CloudDropConnectionString>DefaultEndpointsProtocol=https;AccountName=\$(CloudDropAccountName);AccountKey=\$(CloudDropAccessToken);EndpointSuffix=core.windows.net</CloudDropConnectionString>
+        <CloudResultsConnectionString>DefaultEndpointsProtocol=https;AccountName=\$(CloudResultsAccountName);AccountKey=\$(CloudResultsAccessToken);EndpointSuffix=core.windows.net</CloudResultsConnectionString>
+        <HelixApiEndpoint>https://helix.dot.net/api/2017-04-14/jobs</HelixApiEndpoint>
+        <HelixJobType>test/functional/dotnet-ci</HelixJobType>
+        <HelixSource>${helixSource}</HelixSource>
+        <BuildMoniker>${helixBuild}</BuildMoniker>
+        <HelixCreator>${helixCreator}</HelixCreator>
+        <TargetQueues>Windows.10.Amd64.Open</TargetQueues>
+        <HelixLogFolder>\$(MSBuildThisFileDirectory)</HelixLogFolder>
+        <HelixCorrelationInfoFileName>job-info.json</HelixCorrelationInfoFileName>
+        <HelixJobProperties>{ "operatingSystem": "pizza" }</HelixJobProperties>
+        <ArchivesRoot>\$(MSBuildThisFileDirectory)</ArchivesRoot>
+    </PropertyGroup>
+    <Target Name="Build" DependsOnTargets="HelixCloudBuild"/>
+</Project>
+"""
+                            println fileContent
+                            writeFile file: 'submit-job.proj', text: fileContent
+
+                            withCredentials([string(credentialsId: 'CloudDropAccessToken', variable: 'CloudDropAccessToken'),
+                                 string(credentialsId: 'OutputCloudResultsAccessToken', variable: 'OutputCloudResultsAccessToken')]) {
+                                bat '..\\Tools\\dotnetcli\\dotnet.exe ..\\Tools\\MSBuild.dll submit-job.proj /p:CloudDropAccountName=dotnetbuilddrops /p:CloudDropAccessToken=%CloudDropAccessToken% /p:CloudResultsAccountName=dotnetjobresults /p:CloudResultsAccessToken=%OutputCloudResultsAccessToken%'
+                            }
+                        }
+
+                    }
+
+                    def submittedJson = readJSON file: 'corefx/test/job-info.json'
+
+                    try {
+                        waitForHelixRuns(submittedJson, "The Tests")
+                        assert false : "Expected failure from waitForHelixRuns didn't occur"
+                    }
+                    catch (e) {
+                        echo "Got expected failure from waitForHelixRuns"
+                    }
+                }
+            },
             
             "vars - waitforHelixRuns - failed work item" : {
                 simpleNode('Windows_NT', 'latest') {

--- a/tests/pipeline/pipeline-tests.groovy
+++ b/tests/pipeline/pipeline-tests.groovy
@@ -214,13 +214,7 @@ stage ('Run Tests') {
 
                     def submittedJson = readJSON file: 'corefx/test/job-info.json'
 
-                    try {
-                        waitForHelixRuns(submittedJson, "The Tests")
-                        assert false : "Expected failure from waitForHelixRuns didn't occur"
-                    }
-                    catch (e) {
-                        echo "Got expected failure from waitForHelixRuns"
-                    }
+                    waitForHelixRuns(submittedJson, "The Tests")
                 }
             },
             

--- a/tests/pipeline/pipeline-tests.groovy
+++ b/tests/pipeline/pipeline-tests.groovy
@@ -168,52 +168,60 @@ stage ('Run Tests') {
                     // Get the user that should be associated with the submission
                     def helixCreator = getUser()
 
-                    dir('buildtools') {
-                        git 'https://github.com/dotnet/buildtools'
-                        bat 'powershell bootstrap/bootstrap.ps1 ./ -DotNetInstallBranch "rel/1.0.0-preview2.1"'
+                    dir("corefx") {
+                        git 'https://github.com/dotnet/corefx'
+                        bat 'init-tools.cmd'
 
                         dir('test') {
                             def fileContent = """
-                            <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                                <Import Project="../Tools/CloudTest.Helix.targets"/>
-                                <ItemGroup>
-                                    <HelixWorkItem Include="workItem.zip">
-                                        <Command>run.cmd</Command>
-                                        <PayloadFile>%(Identity)</PayloadFile>
-                                        <WorkItemId>The Work Item</WorkItemId>
-                                        <TimeoutInSeconds>10</TimeoutInSeconds>
-                                    </HelixWorkItem>
-                                </ItemGroup>
-                                <PropertyGroup>
-                                    <CloudDropConnectionString>DefaultEndpointsProtocol=https;AccountName=\$(CloudDropAccountName);AccountKey=\$(CloudDropAccessToken);EndpointSuffix=core.windows.net</CloudDropConnectionString>
-                                    <CloudResultsConnectionString>DefaultEndpointsProtocol=https;AccountName=\$(CloudResultsAccountName);AccountKey=\$(CloudResultsAccessToken);EndpointSuffix=core.windows.net</CloudResultsConnectionString>
-                                    <HelixApiEndpoint>https://helix.dot.net/api/2017-04-14/jobs</HelixApiEndpoint>
-                                    <HelixJobType>test/functional/dotnet-ci</HelixJobType>
-                                    <HelixSource>${helixSource}</HelixSource>
-                                    <BuildMoniker>${helixBuild}</BuildMoniker>
-                                    <HelixCreator>${helixCreator}</HelixCreator>
-                                    <TargetQueues>Windows.10.Amd64.Open</TargetQueues>
-                                    <HelixLogFolder>\$(MSBuildThisFileDirectory)</HelixLogFolder>
-                                    <HelixCorrelationInfoFileName>job-info.json</HelixCorrelationInfoFileName>
-                                    <HelixJobProperties>{ "operatingSystem": "pizza" }</HelixJobProperties>
-                                    <ArchivesRoot>\$(MSBuildThisFileDirectory)</ArchivesRoot>
-                                </PropertyGroup>
-                                <Target Name="Build" DependsOnTargets="HelixCloudBuild"/>
-                            </Project>
-                            """
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="../Tools/CloudTest.Helix.targets"/>
+    <ItemGroup>
+        <HelixWorkItem Include="../../workItem.zip">
+            <Command>run.cmd</Command>
+            <PayloadFile>%(Identity)</PayloadFile>
+            <WorkItemId>The Work Item</WorkItemId>
+            <TimeoutInSeconds>10</TimeoutInSeconds>
+        </HelixWorkItem>
+    </ItemGroup>
+    <PropertyGroup>
+        <CloudDropConnectionString>DefaultEndpointsProtocol=https;AccountName=\$(CloudDropAccountName);AccountKey=\$(CloudDropAccessToken);EndpointSuffix=core.windows.net</CloudDropConnectionString>
+        <CloudResultsConnectionString>DefaultEndpointsProtocol=https;AccountName=\$(CloudResultsAccountName);AccountKey=\$(CloudResultsAccessToken);EndpointSuffix=core.windows.net</CloudResultsConnectionString>
+        <HelixApiEndpoint>https://helix.dot.net/api/2017-04-14/jobs</HelixApiEndpoint>
+        <HelixJobType>test/functional/dotnet-ci</HelixJobType>
+        <HelixSource>${helixSource}</HelixSource>
+        <BuildMoniker>${helixBuild}</BuildMoniker>
+        <HelixCreator>${helixCreator}</HelixCreator>
+        <TargetQueues>Windows.10.Amd64.Open</TargetQueues>
+        <HelixLogFolder>\$(MSBuildThisFileDirectory)</HelixLogFolder>
+        <HelixCorrelationInfoFileName>job-info.json</HelixCorrelationInfoFileName>
+        <HelixJobProperties>{ "operatingSystem": "pizza" }</HelixJobProperties>
+        <ArchivesRoot>\$(MSBuildThisFileDirectory)</ArchivesRoot>
+    </PropertyGroup>
+    <Target Name="Build" DependsOnTargets="HelixCloudBuild"/>
+</Project>
+"""
                             println fileContent
                             writeFile file: 'submit-job.proj', text: fileContent
+
+                            withCredentials([string(credentialsId: 'CloudDropAccessToken', variable: 'CloudDropAccessToken'),
+                                 string(credentialsId: 'OutputCloudResultsAccessToken', variable: 'OutputCloudResultsAccessToken')]) {
+                                bat '..\\Tools\\dotnetcli\\dotnet.exe ..\\Tools\\MSBuild.dll submit-job.proj /p:CloudDropAccountName=dotnetbuilddrops /p:CloudDropAccessToken=%CloudDropAccessToken% /p:CloudResultsAccountName=dotnetjobresults /p:CloudResultsAccessToken=%OutputCloudResultsAccessToken%'
+                            }
                         }
 
-                        withCredentials([string(credentialsId: 'CloudDropAccessToken', variable: 'CloudDropAccessToken'),
-                             string(credentialsId: 'OutputCloudResultsAccessToken', variable: 'OutputCloudResultsAccessToken')]) {
-                            bat 'Tools\\dotnetcli\\dotnet.exe Tools\\MSBuild.exe test\\submit-job.proj /p:CloudDropAccountName=dotnetbuilddrops /p:CloudDropAccessToken=%CloudDropAccessToken% /p:CloudResultsAccountName=dotnetjobresults /p:CloudResultsAccessToken=%OutputCloudResultsAccessToken%'
-                        }
                     }
 
-                    def submittedJson = readJSON 'buildtools/test/job-info.json'
 
-                    waitForHelixRuns(submittedJson, "The Tests");
+                    def submittedJson = readJSON file: 'corefx/test/job-info.json'
+
+                    try {
+                        waitForHelixRuns(submittedJson, "The Tests")
+                        assert false : "Expected failure from waitForHelixRuns didn't occur"
+                    }
+                    catch (e) {
+                        echo "Got expected failure from waitForHelixRuns"
+                    }
                 }
             }
         )


### PR DESCRIPTION
The waitForHelixRuns function was ignoring work item failures when there are no analyses.