### PR TITLE
Update images that had non-functioning custom script extensions

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -237,9 +237,9 @@ class Utilities {
                                 // auto-win2012-20160824 + .NET 4.6.2
                                 '20161027' : 'win2012-20161027',
                                 // win2016-20170303 + Python 3.2
-                                '20170427' : 'win2012-20170427',
+                                '20170427' : 'win2012-20170809',
                                 // win2016-20170303 + Python 3.2
-                                '20170427-elevated' : 'win2012-20170427-elevated',
+                                '20170427-elevated' : 'win2012-20170809-elevated',
                                 // the generic unversioned label except for special cases.
                                 'latest-or-auto':'win2012-20170608',
                                 // Win2012.R2 + VS2013.5 + VS2015.3 + VS15.P3
@@ -299,7 +299,7 @@ class Utilities {
                                 // For elevated runs
                                 'latest-or-auto-elevated':'win2012-20170608-elevated',
                                 // For arm64 builds
-                                'latest-arm64':'win2012-20170328',
+                                'latest-arm64':'win2012-20170810',
                                 // For perf runs
                                 'latest-or-auto-perf':'windows-perf-internal',
                                 // Win2016

--- a/management/nodes/Images.csv
+++ b/management/nodes/Images.csv
@@ -72,6 +72,9 @@ win2012-20170502,win2012-20170502,Windows,system,Microsoft.Compute/Images/dotnet
 win2012-20170502-elevated,win2012-20170502-elevated,Windows,system,Microsoft.Compute/Images/dotnetci/win2012-20170502-osDisk.86bcc6ca-84b2-4fd2-affe-9328f98c0f76.vhd,All,./startupScripts/win2012-win2012-20170502.ps1,D:\j
 win2012-20170608,win2012-20170608,Windows,system,Microsoft.Compute/Images/dotnetci/win2012-20170608-osDisk.be1ca927-eb97-4e77-9eba-c3e379ba6986.vhd,All,./startupScripts/win2012-20170608.ps1,D:\j
 win2012-20170608-elevated,win2012-20170608-elevated,Windows,system,Microsoft.Compute/Images/dotnetci/win2012-20170608-osDisk.be1ca927-eb97-4e77-9eba-c3e379ba6986.vhd,All,./startupScripts/win2012-20170608-elevated.ps1,D:\j
+win2012-20170809,win2012-20170809,Windows,system,Microsoft.Compute/Images/dotnetci/win2012-20170809-osDisk.ef241cfc-5386-4f2c-aa97-6d18e8e3b743.vhd,All,./startupScripts/win2012-20170809.ps1,D:\j
+win2012-20170809-elevated,win2012-20170809-elevated,Windows,system,Microsoft.Compute/Images/dotnetci/win2012-20170809-osDisk.ef241cfc-5386-4f2c-aa97-6d18e8e3b743.vhd,All,./startupScripts/win2012-20170809-elevated.ps1,D:\j
+win2012-20170810,win2012-20170810,Windows,system,Microsoft.Compute/Images/dotnetci/win2012-20170810-osDisk.ba2fc334-b604-4e18-9990-96bdee12ee0b.vhd,All,./startupScripts/win2012-20170810.ps1,D:\j
 win2016-base,win2016-base,Windows,system,Microsoft.Compute/Images/dotnetci/win2016-20170214-osDisk.bb90cfd5-b990-4acf-86e6-cfd35a9aae81.vhd,All,./startupScripts/win2016-base.ps1,D:\j
 win2016-base-internal,win2016-base-internal,Windows,system,Microsoft.Compute/Images/dotnetci/win2016-20170214-osDisk.bb90cfd5-b990-4acf-86e6-cfd35a9aae81.vhd,All,./startupScripts/win2016-base-internal.ps1,D:\j
 win2016-20161018-1,win2016-20161018-1,Windows,system,Microsoft.Compute/Images/dotnetci/win2016-20161018-1-osDisk.98497130-7742-4c2c-872b-5aadf2065311.vhd,All,./startupScripts/win2016-20161018-1.ps1,D:\j

--- a/management/nodes/startupScripts/win2012-20170809-elevated.ps1
+++ b/management/nodes/startupScripts/win2012-20170809-elevated.ps1
@@ -1,0 +1,66 @@
+Set-ExecutionPolicy Unrestricted
+
+$machineSetupLog = 'C:\setup.log'
+$jenkinsServerUrl = $args[0]
+echo ('Jenkins Server URL: {0}' -f $jenkinsServerUrl) | Out-File -Append $machineSetupLog
+$vmName = $args[1]
+echo ('Virtual Machine Name: {0}' -f $vmName) | Out-File -Append $machineSetupLog
+$secret = $args[2]
+echo ('Secret: {0}' -f $secret) | Out-File -Append $machineSetupLog
+
+$winLogonRegistryPath = 'hklm:\software\microsoft\windows nt\currentversion\winlogon\'
+$jenkinsDirectory = 'C:\Jenkins'
+$jenkinsLaunchCmd = Join-Path -Path $jenkinsDirectory -ChildPath 'launch.cmd'
+$jenkinsStartupScript = Join-Path -Path $jenkinsDirectory -ChildPath 'jenkins-windows-startup.ps1'
+$jenkinsLogFile = Join-Path -Path $jenkinsDirectory -ChildPath 'log.txt'
+# The image needs to have LUA off to run properly. If you want the VM to have administrative permissions for
+# everything set $enableLUA to $false.
+$enableLUA = $true
+$enableLUARegistryPath = 'hklm:\software\Microsoft\Windows\CurrentVersion\policies\system\'
+
+# Create the Jenkins directory
+if (!(Test-Path -Path $jenkinsDirectory))
+{
+    Write-Output ('Creating Jenkins Directory: {0}' -f $jenkinsDirectory) | Out-File -Append $machineSetupLog
+    New-Item -Path $jenkinsDirectory -Force -ItemType Directory
+}
+
+# Set the time zone
+tzutil /s "Pacific Standard Time"
+
+# Generate the launch cmd
+$content = 'powershell.exe {0} -URL {1} -VMName {2} -Secret {3} > {4}' -f $jenkinsStartupScript, $jenkinsServerUrl, $vmName, $secret, $jenkinsLogFile
+Write-Output ('Creating Jenkins Launcher. File: {0}; Content: {1}' -f $jenkinsLaunchCmd, $content) | Out-File  -Append $machineSetupLog
+$content | Out-File -FilePath $jenkinsLaunchCmd -Encoding ascii -Force
+
+# Set up auto-login
+Write-Output 'Registering dotnet-bot for auto-login' | Out-File -Append $machineSetupLog
+
+New-ItemProperty -Path $winLogonRegistryPath -Name 'DefaultUserName' -Value 'dotnet-bot' -PropertyType string -Force
+New-ItemProperty -Path $winLogonRegistryPath -Name 'DefaultPassword' -Value '<pass>' -PropertyType string -Force
+
+New-ItemProperty -Path $winLogonRegistryPath -Name 'AutoAdminLogon' -Value '1' -PropertyType string -Force
+
+# Enable LUA
+if ($enableLUA)
+{
+    Write-Output 'Enabling UAC/LUA' | Out-File -Append $machineSetupLog
+    New-ItemProperty -Path $enableLUARegistryPath -Name 'EnableLUA' -Value 1 -PropertyType DWORD -Force
+}
+
+# Register the logon task if it doesn't exist
+$scheduledTaskExists = Get-ScheduledTask | Where-Object { $_.TaskName -like "Jenkins-Startup" }
+
+if (!$scheduledTaskExists) {
+    Write-Output 'Registering the launch script to run on user login' | Out-File -Append $machineSetupLog
+    $scheduledTaskTrigger = New-ScheduledTaskTrigger -AtLogOn -User dotnet-bot
+    $scheduledTaskAction = New-ScheduledTaskAction -Execute C:\Jenkins\launch.cmd
+    $scheduledTaskSettings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -Priority 4 -ExecutionTimeLimit ([TimeSpan]::Zero)
+    $scheduledTaskPrincipal = New-ScheduledTaskPrincipal -UserId dotnet-bot -LogonType Interactive
+    Register-ScheduledTask Jenkins-Startup -Action $scheduledTaskAction -Trigger $scheduledTaskTrigger -Principal $scheduledTaskPrincipal -Settings $scheduledTaskSettings
+}
+
+Remove-Item -Path "C:\Program Files\Git\mingw64\etc\gitconfig" -Force
+
+Write-Output 'Rebooting' | Out-File -Append $machineSetupLog
+Restart-Computer -Force

--- a/management/nodes/startupScripts/win2012-20170810.ps1
+++ b/management/nodes/startupScripts/win2012-20170810.ps1
@@ -1,0 +1,66 @@
+Set-ExecutionPolicy Unrestricted
+
+$machineSetupLog = 'C:\setup.log'
+$jenkinsServerUrl = $args[0]
+echo ('Jenkins Server URL: {0}' -f $jenkinsServerUrl) | Out-File -Append $machineSetupLog
+$vmName = $args[1]
+echo ('Virtual Machine Name: {0}' -f $vmName) | Out-File -Append $machineSetupLog
+$secret = $args[2]
+echo ('Secret: {0}' -f $secret) | Out-File -Append $machineSetupLog
+
+$winLogonRegistryPath = 'hklm:\software\microsoft\windows nt\currentversion\winlogon\'
+$jenkinsDirectory = 'C:\Jenkins'
+$jenkinsLaunchCmd = Join-Path -Path $jenkinsDirectory -ChildPath 'launch.cmd'
+$jenkinsStartupScript = Join-Path -Path $jenkinsDirectory -ChildPath 'jenkins-windows-startup.ps1'
+$jenkinsLogFile = Join-Path -Path $jenkinsDirectory -ChildPath 'log.txt'
+# The image needs to have LUA off to run properly. If you want the VM to have administrative permissions for
+# everything set $enableLUA to $false.
+$enableLUA = $true
+$enableLUARegistryPath = 'hklm:\software\Microsoft\Windows\CurrentVersion\policies\system\'
+
+# Create the Jenkins directory
+if (!(Test-Path -Path $jenkinsDirectory))
+{
+    Write-Output ('Creating Jenkins Directory: {0}' -f $jenkinsDirectory) | Out-File -Append $machineSetupLog
+    New-Item -Path $jenkinsDirectory -Force -ItemType Directory
+}
+
+# Set the time zone
+tzutil /s "Pacific Standard Time"
+
+# Generate the launch cmd
+$content = 'powershell.exe {0} -URL {1} -VMName {2} -Secret {3} > {4}' -f $jenkinsStartupScript, $jenkinsServerUrl, $vmName, $secret, $jenkinsLogFile
+Write-Output ('Creating Jenkins Launcher. File: {0}; Content: {1}' -f $jenkinsLaunchCmd, $content) | Out-File  -Append $machineSetupLog
+$content | Out-File -FilePath $jenkinsLaunchCmd -Encoding ascii -Force
+
+# Set up auto-login
+Write-Output 'Registering dotnet-bot for auto-login' | Out-File -Append $machineSetupLog
+
+New-ItemProperty -Path $winLogonRegistryPath -Name 'DefaultUserName' -Value 'dotnet-bot' -PropertyType string -Force
+New-ItemProperty -Path $winLogonRegistryPath -Name 'DefaultPassword' -Value '<pass>' -PropertyType string -Force
+
+New-ItemProperty -Path $winLogonRegistryPath -Name 'AutoAdminLogon' -Value '1' -PropertyType string -Force
+
+# Enable LUA
+if ($enableLUA)
+{
+    Write-Output 'Enabling UAC/LUA' | Out-File -Append $machineSetupLog
+    New-ItemProperty -Path $enableLUARegistryPath -Name 'EnableLUA' -Value 1 -PropertyType DWORD -Force
+}
+
+# Register the logon task if it doesn't exist
+$scheduledTaskExists = Get-ScheduledTask | Where-Object { $_.TaskName -like "Jenkins-Startup" }
+
+if (!$scheduledTaskExists) {
+    Write-Output 'Registering the launch script to run on user login' | Out-File -Append $machineSetupLog
+    $scheduledTaskTrigger = New-ScheduledTaskTrigger -AtLogOn -User dotnet-bot
+    $scheduledTaskAction = New-ScheduledTaskAction -Execute C:\Jenkins\launch.cmd
+    $scheduledTaskSettings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -Priority 4 -ExecutionTimeLimit ([TimeSpan]::Zero)
+    $scheduledTaskPrincipal = New-ScheduledTaskPrincipal -UserId dotnet-bot -LogonType Interactive
+    Register-ScheduledTask Jenkins-Startup -Action $scheduledTaskAction -Trigger $scheduledTaskTrigger -Principal $scheduledTaskPrincipal -Settings $scheduledTaskSettings
+}
+
+Remove-Item -Path "C:\Program Files\Git\mingw64\etc\gitconfig" -Force
+
+Write-Output 'Rebooting' | Out-File -Append $machineSetupLog
+Restart-Computer -Force


### PR DESCRIPTION
Custom script extensions were updated from 1.8->1.9, which caused problems with these two images.
Running C:\Packages\..\resetState.cmd in the custom script extension that refuses to run the script (in this case 1.8) and then recapturing fixes the issue.