### PR TITLE
Add getUserEmail function

### DIFF
--- a/tests/pipeline/pipeline-tests.groovy
+++ b/tests/pipeline/pipeline-tests.groovy
@@ -132,6 +132,26 @@ stage ('Run Tests') {
                 assert getUser() != null : "Expected getUser would return valid value."
             },
 
+            "getUserEmail - GitHub PR" : {
+                withEnv(['ghprbPullAuthorEmail=blah@blah.com', 'ghprbGhRepository=foo/bar']) {
+                    def userEmail = getUserEmail()
+                    assert userEmail == 'blah@blah.com' : "Expected getUserEmail would return blah@blah.com, actually got ${userEmail}"
+                }
+            },
+
+            "getUserEmail - GitHub PR, no email": {
+                withEnv(['ghprbPullAuthorLogin=baz', 'ghprbGhRepository=foo/bar', 'ghprbPullAuthorEmail=']) {
+                    def userEmail = getUserEmail()
+                    assert userEmail == 'baz@github.login' : "Expected getUserEmail would return baz@github.login, actually got ${userEmail}"
+                }
+            },
+
+            // Testing non-PR getUserEmail is tough as it returns different values based on the cause of the run.
+            // You can't mock causes in here without opening up untrusted APIs either.
+            "getUserEmail - non mocked behavior" : {
+                assert getUserEmail() != null : "Expected getUserEmail would return valid value."
+            },
+
             "vars - waitforHelixRuns - passed work item" : {
                 simpleNode('Windows_NT', 'latest') {
                     dir('workItem') {

--- a/vars/getUserEmail.groovy
+++ b/vars/getUserEmail.groovy
@@ -1,0 +1,39 @@
+/**
+  * Retrieves the user email that this job was associated with.
+  * This is:
+  *     dotnet-bot@microsoft.com (default) if triggered by a user.
+  *     logged in github user's email - If triggered manually through the UI
+  *     pr originator (ghprbPullAuthorEmail) - If triggered via the PR builder (even if triggered by another user)
+  *     pr originator's github username + @github.login - If triggered via the PR builder and email is not available
+  * @return User associated with this run.
+  */
+def call() {
+    def isPRJob = isPR();
+    if (isPRJob) {
+        def ghPullUserEmail = env["ghprbPullAuthorEmail"]
+        if (isNullOrEmpty(ghPullUserEmail)) {
+            ghPullUserEmail = getUser() + "@github.login"
+        }
+        assert !isNullOrEmpty(ghPullUserEmail) : "Could not locate the pull author email."
+        return ghPullUserEmail
+    }
+    else {
+        // Do some digging to determine how the job was launched.  There are a couple easy possibilities:
+        
+        // user ID cause -> manually launched runs
+        def userIdCause = currentBuild.rawBuild.getCause(hudson.model.Cause$UserIdCause)
+
+        if (userIdCause != null) {
+            def userId = userIdCause.getUserId()
+            def userIdEmail = hudson.model.User.get(userId).getProperty(hudson.tasks.Mailer.class).getAddress()
+            if (isNullOrEmpty(userIdEmail)) {
+                userIdEmail = userId + "@github.login"
+            }
+            return userIdEmail
+        }
+        else {
+            // Return dotnet-bot as the default
+            return 'dotnet-bot@microsoft.com'
+        }
+    }
+}


### PR DESCRIPTION
When uploading perf results to benchview, we want to supply the email
address of the user who initiated the run. Return the github email
address if accessible, and if not, return <username>@github.login, so
that we don't collide with potential actual @github.com email addresses.