### PR TITLE
Use scoped refspecs

### DIFF
--- a/src/jobs/generation/MetaGenerator.groovy
+++ b/src/jobs/generation/MetaGenerator.groovy
@@ -319,7 +319,7 @@ repos.each { repoInfo ->
                                 // TODO: VSTS PR refspec
                             }
                             else {
-                                refspec('+refs/pull/*:refs/remotes/origin/pr/*')
+                                refspec('+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*')
                             }
                         }
                     }
@@ -361,7 +361,7 @@ repos.each { repoInfo ->
                                 // TODO: VSTS PR refspec
                             }
                             else {
-                                refspec('+refs/pull/*:refs/remotes/origin/pr/*')
+                                refspec('+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*')
                             }
                         }
                     }

--- a/src/jobs/generation/RootGenerator.groovy
+++ b/src/jobs/generation/RootGenerator.groovy
@@ -43,7 +43,7 @@ folder('GenPRTest') {}
                         else {
                             github("dotnet/dotnet-ci")
                             // Set the refspec
-                            refspec('+refs/pull/*:refs/remotes/origin/pr/*')
+                            refspec('+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*')
                         }
                     }
 
@@ -63,7 +63,7 @@ folder('GenPRTest') {}
                         else {
                             github("dotnet/dotnet-ci")
                             // Set the refspec
-                            refspec('+refs/pull/*:refs/remotes/origin/pr/*')
+                            refspec('+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*')
                         }
                     }
 

--- a/src/jobs/generation/Utilities.groovy
+++ b/src/jobs/generation/Utilities.groovy
@@ -7,7 +7,7 @@ class Utilities {
 
     private static String DefaultBranchOrCommitPR = '${sha1}'
     private static String DefaultBranchOrCommitPush = '*/master'
-    private static String DefaultRefSpec = '+refs/pull/*:refs/remotes/origin/pr/*'
+    private static String DefaultRefSpec = '+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*'
 
     /**
      * Get the folder name for a job.

--- a/src/org/dotnet/ci/pipelines/scm/GithubPipelineScm.groovy
+++ b/src/org/dotnet/ci/pipelines/scm/GithubPipelineScm.groovy
@@ -39,7 +39,7 @@ class GithubPipelineScm implements PipelineScm {
                 stringParam('sha1', '', 'Incoming sha1 parameter from the GHPRB plugin.')
                 stringParam('GitBranchOrCommit', '${sha1}', 'Git branch or commit to build.  If a branch, builds the HEAD of that branch.  If a commit, then checks out that specific commit.')
                 stringParam('GitRepoUrl', Utilities.calculateGitURL(this._project), 'Git repo to clone.')
-                stringParam('GitRefSpec', '+refs/pull/*:refs/remotes/origin/pr/*', 'RefSpec.  WHEN SUBMITTING PRIVATE JOB FROM YOUR OWN REPO, CLEAR THIS FIELD (or it won\'t find your code)')
+                stringParam('GitRefSpec', '+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*', 'RefSpec.  WHEN SUBMITTING PRIVATE JOB FROM YOUR OWN REPO, CLEAR THIS FIELD (or it won\'t find your code)')
                 stringParam('DOTNET_CLI_TELEMETRY_PROFILE', "IsInternal_CIServer;${_project}", 'This is used to differentiate the internal CI usage of CLI in telemetry.  This gets exposed in the environment and picked up by the CLI product.')
                 // Project name (without org)
                 stringParam('GithubProjectName', Utilities.getProjectName(_project), 'Project name ')

--- a/src/org/dotnet/ci/pipelines/scm/VSTSPipelineScm.groovy
+++ b/src/org/dotnet/ci/pipelines/scm/VSTSPipelineScm.groovy
@@ -41,7 +41,7 @@ class VSTSPipelineScm implements PipelineScm {
                 stringParam('sha1', '', 'Incoming sha1 parameter from the GHPRB plugin.')
                 stringParam('GitBranchOrCommit', '${sha1}', 'Git branch or commit to build.  If a branch, builds the HEAD of that branch.  If a commit, then checks out that specific commit.')
                 stringParam('GitRepoUrl', this.getGitUrl(), 'Git repo to clone.')
-                stringParam('GitRefSpec', '+refs/pull/*:refs/remotes/origin/pr/*', 'RefSpec.  WHEN SUBMITTING PRIVATE JOB FROM YOUR OWN REPO, CLEAR THIS FIELD (or it won\'t find your code)')
+                stringParam('GitRefSpec', '+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*', 'RefSpec.  WHEN SUBMITTING PRIVATE JOB FROM YOUR OWN REPO, CLEAR THIS FIELD (or it won\'t find your code)')
                 stringParam('DOTNET_CLI_TELEMETRY_PROFILE', "IsInternal_CIServer;${_project}", 'This is used to differentiate the internal CI usage of CLI in telemetry.  This gets exposed in the environment and picked up by the CLI product.')
                 stringParam('RepoName', Utilities.getRepoName(this._project), 'Repo name')
                 stringParam('OrgOrProjectName', Utilities.getOrgOrProjectName(this._project), 'Organization/VSTS project name')


### PR DESCRIPTION
Use scoped for PRs to work around issues with newer gits being much much slower checking out repos with large numbers of refs.
https://github.com/dotnet/core-eng/issues/1700