### PR TITLE
Use scoped refspec

### DIFF
--- a/jobs/generation/MetaGenerator.groovy
+++ b/jobs/generation/MetaGenerator.groovy
@@ -305,7 +305,7 @@ repos.each { repoInfo ->
                         github(repoInfo.project)
 
                         if (isPRTest) {
-                            refspec('+refs/pull/*:refs/remotes/origin/pr/*')
+                            refspec('+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*')
                         }
                     }
                     def targetDir = Utilities.getProjectName(repoInfo.project)

--- a/jobs/generation/RootGenerator.groovy
+++ b/jobs/generation/RootGenerator.groovy
@@ -41,7 +41,7 @@ folder('GenPRTest') {}
                         github("dotnet/dotnet-ci")
 
                         // Set the refspec
-                        refspec('+refs/pull/*:refs/remotes/origin/pr/*')
+                        refspec('+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*')
                     }
 
                     branch("*/master")
@@ -56,7 +56,7 @@ folder('GenPRTest') {}
                         github("dotnet/dotnet-ci")
 
                         // Set the refspec
-                        refspec('+refs/pull/*:refs/remotes/origin/pr/*')
+                        refspec('+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*')
                     }
 
                     branch('${sha1}')

--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -4,7 +4,7 @@ class Utilities {
 
     private static String DefaultBranchOrCommitPR = '${sha1}'
     private static String DefaultBranchOrCommitPush = '*/master'
-    private static String DefaultRefSpec = '+refs/pull/*:refs/remotes/origin/pr/*'
+    private static String DefaultRefSpec = '+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*'
 
     /**
      * Get the folder name for a job.


### PR DESCRIPTION
Use scoped refspec for PRs to work around a performance issue with newer git implementations, especially on Windows