### PR TITLE
Add simpleNode function that takes a label

### DIFF
--- a/tests/pipeline/pipeline-tests.groovy
+++ b/tests/pipeline/pipeline-tests.groovy
@@ -64,6 +64,14 @@ stage ('Run Tests') {
                 }
             },
 
+            "simpleNode - osx-10.12" : {
+                timeout (60) {
+                    simpleNode('osx-10.12') {
+                        checkoutRepo()
+                    }
+                }
+            },
+
             "getBranch" : {
                 // getBranch
                 simpleNode('Windows_NT', 'latest') {

--- a/vars/simpleNode.groovy
+++ b/vars/simpleNode.groovy
@@ -2,7 +2,7 @@ import org.dotnet.ci.util.Agents
 
 // Example:
 //
-// simpleNode('OSX10.12', 'latest') { <= braces define the closure, implicitly passed as the last parameter
+// simpleNode('osx-10.12') { <= braces define the closure, implicitly passed as the last parameter
 //     checkout scm
 //     sh 'echo Hello world'
 // }
@@ -10,11 +10,10 @@ import org.dotnet.ci.util.Agents
 // Runs a set of functionality on the default node
 // that supports docker.
 // Parameters:
-//  osName - Docker image to use
-//  imageVersion - Version of the OS image.  See Agents.getMachineAffinity
+//  label - label to use
 //  body - Closure, see example
-def call(String osName, version, Closure body) {
-    node (Agents.getAgentLabel(osName, version)) {
+def call(String label, Closure body) {
+    node (label) {
         // Clean.  Currently processes are killed at the end of the node block, but we don't have an easy way to run the cleanup
         // after the node block exits currently.  Cleaning at the start should be sufficient.
         step([$class: 'WsCleanup'])
@@ -53,4 +52,21 @@ def call(String osName, version, Closure body) {
             }
         }
     }
+}
+
+// Example:
+//
+// simpleNode('OSX10.12', 'latest') { <= braces define the closure, implicitly passed as the last parameter
+//     checkout scm
+//     sh 'echo Hello world'
+// }
+
+// Runs a set of functionality on the default node
+// that supports docker.
+// Parameters:
+//  osName - Docker image to use
+//  imageVersion - Version of the OS image.  See Agents.getMachineAffinity
+//  body - Closure, see example
+def call(String osName, version, Closure body) {
+    simpleNode(Agents.getAgentLabel(osName, version), body)
 }


### PR DESCRIPTION
For non-vm machines, we want to be able to specify them by their label.
This change adds an overload to simpleNode that takes a single label as
argument. This change also converts the osName + version version of
simpleNode to use the new overload.