### PR TITLE
New image with Docker 17.06.1-ee-2.

### DIFF
--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -330,6 +330,8 @@ class Utilities {
                                 [
                                 // First working containers image
                                 'win2016-20161018-1':'win2016-20161018-1',
+                                // Docker 17.06.1-ee-2
+                                'win2016-20170921':'win2016-20170921',
                                 // Latest auto image w/docker (move to latest-or-auto when possible)
                                 'latest-containers':'win2016-20161018-1',
                                 // Latest auto image.

--- a/jobs/generation/Utilities.groovy
+++ b/jobs/generation/Utilities.groovy
@@ -332,6 +332,7 @@ class Utilities {
                                 'win2016-20161018-1':'win2016-20161018-1',
                                 // Docker 17.06.1-ee-2
                                 'win2016-20170921':'win2016-20170921',
+                                'latest-docker':'win2016-20170921',
                                 // Latest auto image w/docker (move to latest-or-auto when possible)
                                 'latest-containers':'win2016-20161018-1',
                                 // Latest auto image.

--- a/management/nodes/Create-VM.ps1
+++ b/management/nodes/Create-VM.ps1
@@ -30,7 +30,6 @@ param (
     [string]$ImageVHD = $null,
     [ValidateSet('Windows','Linux')]
     [string]$OperatingSystem = $null,
-    [ValidateLength(0, 14)]
     [string]$VMName = $(Read-Host -prompt "VM name to deploy"),
     [string]$ResourceGroupName = 'dotnet-ci-user-vms',
     [string]$Location = 'westus2',

--- a/management/nodes/Create-VM.ps1
+++ b/management/nodes/Create-VM.ps1
@@ -30,6 +30,7 @@ param (
     [string]$ImageVHD = $null,
     [ValidateSet('Windows','Linux')]
     [string]$OperatingSystem = $null,
+    [ValidateLength(0, 14)]
     [string]$VMName = $(Read-Host -prompt "VM name to deploy"),
     [string]$ResourceGroupName = 'dotnet-ci-user-vms',
     [string]$Location = 'westus2',
@@ -153,5 +154,5 @@ else {
 New-AzureRmVM -ResourceGroupName $ResourceGroupName -Location $Location -VM $vm
 
 # Retrieve the connection info
-Write-Output "\nRetrieving connection information..."
+Write-Output "`r`nRetrieving connection information..."
 .\Get-Connection-Info.ps1 $VMName -ResourceGroupName $ResourceGroupName

--- a/management/nodes/Images.csv
+++ b/management/nodes/Images.csv
@@ -48,3 +48,4 @@ win2016-20170814,win2016-20170814,Windows,system,Microsoft.Compute/Images/dotnet
 win2016-20170814-internal,win2016-20170814-internal,Windows,system,Microsoft.Compute/Images/dotnetci/win2016-20170814-osDisk.0d0b4de0-af40-485b-b037-6f4535e150dc.vhd,All,./startupScripts/win2016-20170814-internal.ps1,D:\j
 win2016-20170919,win2016-20170919,Windows,system,Microsoft.Compute/Images/dotnetci/win2016-20170919-osDisk.be037f44-ef3a-47a8-8bc7-5bc447dffd40.vhd,All,./startupScripts/win2016-20170919.ps1,D:\j
 win2016-20170919-internal,win2016-20170919-internal,Windows,system,Microsoft.Compute/Images/dotnetci/win2016-20170919-osDisk.be037f44-ef3a-47a8-8bc7-5bc447dffd40.vhd,All,./startupScripts/win2016-20170919-internal.ps1,D:\j
+win2016-20170921,win2016-20170921,Windows,system,Microsoft.Compute/Images/dotnetci/win2016-20170921-osDisk.4b902c34-c035-4ecc-8e99-5b0a214ba653.vhd,All,./startupScripts/win2016-20170921.ps1,D:\j

--- a/management/nodes/startupScripts/win2016-20170921.ps1
+++ b/management/nodes/startupScripts/win2016-20170921.ps1
@@ -1,0 +1,77 @@
+Set-ExecutionPolicy Unrestricted
+
+$machineSetupLog = 'C:\setup.log'
+$jenkinsServerUrl = $args[0]
+echo ('Jenkins Server URL: {0}' -f $jenkinsServerUrl) | Out-File -Append $machineSetupLog
+$vmName = $args[1]
+echo ('Virtual Machine Name: {0}' -f $vmName) | Out-File -Append $machineSetupLog
+$secret = $args[2]
+echo ('Secret: {0}' -f $secret) | Out-File -Append $machineSetupLog
+
+$winLogonRegistryPath = 'hklm:\software\microsoft\windows nt\currentversion\winlogon\'
+$jenkinsDirectory = 'C:\Jenkins'
+$jenkinsLaunchCmd = Join-Path -Path $jenkinsDirectory -ChildPath 'launch.cmd'
+$jenkinsStartupScript = Join-Path -Path $jenkinsDirectory -ChildPath 'jenkins-windows-startup.ps1'
+$jenkinsLogFile = Join-Path -Path $jenkinsDirectory -ChildPath 'log.txt'
+# The image needs to have LUA off to run properly. If you want the VM to have administrative permissions for
+# everything set $enableLUA to $false.
+$enableLUA = $true
+$enableLUARegistryPath = 'hklm:\software\Microsoft\Windows\CurrentVersion\policies\system\'
+$enableDumps = $true
+
+# Create the Jenkins directory
+if (!(Test-Path -Path $jenkinsDirectory))
+{
+    Write-Output ('Creating Jenkins Directory: {0}' -f $jenkinsDirectory) | Out-File -Append $machineSetupLog
+    New-Item -Path $jenkinsDirectory -Force -ItemType Directory
+}
+
+# Set the time zone
+tzutil /s "Pacific Standard Time"
+
+# Disable the git credential manager
+git config --system --unset credential.helper
+
+# Generate the launch cmd
+$content = 'powershell.exe {0} -URL {1} -VMName {2} -Secret {3} > {4}' -f $jenkinsStartupScript, $jenkinsServerUrl, $vmName, $secret, $jenkinsLogFile
+Write-Output ('Creating Jenkins Launcher. File: {0}; Content: {1}' -f $jenkinsLaunchCmd, $content) | Out-File  -Append $machineSetupLog
+$content | Out-File -FilePath $jenkinsLaunchCmd -Encoding ascii -Force
+
+# Set up auto-login
+Write-Output 'Registering dotnet-bot for auto-login' | Out-File -Append $machineSetupLog
+
+New-ItemProperty -Path $winLogonRegistryPath -Name 'DefaultUserName' -Value 'dotnet-bot' -PropertyType string -Force
+New-ItemProperty -Path $winLogonRegistryPath -Name 'DefaultPassword' -Value '<pass>' -PropertyType string -Force
+
+New-ItemProperty -Path $winLogonRegistryPath -Name 'AutoAdminLogon' -Value '1' -PropertyType string -Force
+
+# Enable dumps if desired
+if ($enableDumps)
+{
+    # Dumps options
+    $enableDumpsRegistryPath = 'hklm:\software\Microsoft\Windows\Windows Error Reporting\LocalDumps\'
+    $dumpPath = '%TMP%\CoreRunCrashDumps'
+    $dumpCount = 5
+    $dumpType = 2
+    $executablesToDump = @('corerun.exe', 'java.exe')
+
+    foreach ($executable in $executablesToDump)
+    {
+        $regPath = $enableDumpsRegistryPath + $executable + '\'
+        Write-Output 'Enabling Crash Dumps' | Out-File  -Append $machineSetupLog
+        New-Item -Path $regPath -Force
+        New-ItemProperty -Path $regPath -Name 'DumpFolder' -Value $dumpPath -PropertyType EXPANDSTRING -Force
+        New-ItemProperty -Path $regPath -Name 'DumpCount' -Value $dumpCount -PropertyType DWORD -Force
+        New-ItemProperty -Path $regPath -Name 'DumpType' -Value $dumpType -PropertyType DWORD -Force
+    }
+}
+
+# Enable LUA
+if ($enableLUA)
+{
+    Write-Output 'Enabling UAC/LUA' | Out-File -Append $machineSetupLog
+    New-ItemProperty -Path $enableLUARegistryPath -Name 'EnableLUA' -Value 1 -PropertyType DWORD -Force
+}
+
+Write-Output 'Rebooting' | Out-File -Append $machineSetupLog
+Restart-Computer -Force


### PR DESCRIPTION
Introducing a new image Docker 17.06.1-ee-2, which supports multi-stage builds. To prepare this image I did the following -

1. Create VM using win2016-20161018-1
2. Remove Containers feature using `Uninstall-WindowsFeature Containers` PowerShell command
3. Install Docker EE as described at https://store.docker.com/editions/enterprise/docker-ee-server-windows
4. Sysprep and deploy using the instructions at https://github.com/dotnet/core-eng/blob/master/Documentation/Jenkins/Adding-New-Jenkins-VM.md

@mmitche please suggest how do I switch CI from `win2016-20161018-1` to `win2016-20170921` and validate if this new image works at all?

@MichaelSimons PTAL

@karajas FYI.
