### PR TITLE
Add helix event sending, support docker args in simpleDockerNode, misc other utils

### DIFF
--- a/src/org/dotnet/ci/pipelines/Pipeline.groovy
+++ b/src/org/dotnet/ci/pipelines/Pipeline.groovy
@@ -57,7 +57,7 @@ class Pipeline {
     // Replace all the unsafe characters in the input string
     // with _
     // See Jenkins.java's checkGoodName for source of the bad characters
-    private String getValidJobNameString(String input) {
+    private static String getValidJobNameString(String input) {
         String finalString = ''
         for (int i = 0; i < input.length(); i++) {
             char ch = input.charAt(i)
@@ -74,7 +74,7 @@ class Pipeline {
         return shortenString(finalString, maxElementLength)
     }
 
-    private String shortenString(String input, int max) {
+    private static String shortenString(String input, int max) {
         if (input.length() < max) {
             return input
         }
@@ -93,7 +93,7 @@ class Pipeline {
 
     // Determines a full job name for a pipeline job from the base job and parameter set
     // 
-    private String getPipelineJobName(Map<String,Object> parameters = [:]) {
+    public static String getPipelineJobName(String _baseJobName, Map<String,Object> parameters = [:]) {
         // Take the base job name and append '-'' if there are any parameters
         // If parameters, walk the parameter list.  Append X=Y forms, replacing any
         // invalid characters with _, separated by comma
@@ -203,13 +203,13 @@ class Pipeline {
      *
      * @return Newly created job
      */
-    public def triggerPipelineOnEveryPR(String context, Map<String,Object> parameters = [:]) {
+    public def triggerPipelineOnEveryPR(String context, Map<String,Object> parameters = [:], String jobName = null) {
         if (this._scm.getScmType() == 'VSTS') {
             // TODO: VSTS PR checks
             assert false : "VSTS PR pipelines are NYI"
         }
         else if (this._scm.getScmType() == 'GitHub') {
-            return triggerPipelineOnEveryGithubPR(context, parameters)
+            return triggerPipelineOnEveryGithubPR(context, parameters, jobName)
         }
         else {
             assert false : "NYI, unknown scm type"
@@ -220,9 +220,9 @@ class Pipeline {
     // Parameters:
     //  context - The context that appears for the status check in the Github UI
     //  parameter - Optional set of key/value pairs of string parameters that will be passed to the pipeline
-    public def triggerPipelineOnEveryGithubPR(String context, Map<String,Object> parameters = [:]) {
+    public def triggerPipelineOnEveryGithubPR(String context, Map<String,Object> parameters = [:], String jobName = null) {
         // Create the default trigger phrase based on the context
-        return triggerPipelineOnEveryGithubPR(context, null, parameters)
+        return triggerPipelineOnEveryGithubPR(context, null, parameters, jobName)
     }
 
     // Triggers a puipeline on every Github PR, with a custom trigger phrase.
@@ -230,7 +230,7 @@ class Pipeline {
     //  context - The context that appears for the status check in the Github UI
     //  triggerPhrase - The trigger phrase that can relaunch the pipeline
     //  parameters - Optional set of key/value pairs of string parameters that will be passed to the pipeline
-    public def triggerPipelineOnEveryGithubPR(String context, String triggerPhrase, Map<String,Object> parameters = [:]) {
+    public def triggerPipelineOnEveryGithubPR(String context, String triggerPhrase, Map<String,Object> parameters = [:], String jobName = null) {
         // Create a trigger builder and pass it to the generic triggerPipelineOnEvent
         GithubTriggerBuilder builder = GithubTriggerBuilder.triggerOnPullRequest()
         builder.setGithubContext(context)
@@ -244,7 +244,7 @@ class Pipeline {
         builder.triggerForBranch(this._scm.getBranch())
 
         // Call the generic API
-        return triggerPipelineOnEvent(builder, parameters)
+        return triggerPipelineOnEvent(builder, parameters, jobName)
     }
 
     // Triggers a pipeline on a Github PR when the specified phrase is commented.
@@ -252,7 +252,7 @@ class Pipeline {
     //  context - The context that appears for the status check in the Github UI
     //  triggerPhrase - The trigger phrase that can relaunch the pipeline
     //  parameters - Optional set of key/value pairs of string parameters that will be passed to the pipeline
-    public def triggerPipelineOnGithubPRComment(String context, String triggerPhrase, Map<String,Object> parameters = [:]) {
+    public def triggerPipelineOnGithubPRComment(String context, String triggerPhrase, Map<String,Object> parameters = [:], String jobName = null) {
         // Create the trigger event and call the helper API
         GithubTriggerBuilder builder = GithubTriggerBuilder.triggerOnPullRequest()
         builder.setGithubContext(context)
@@ -263,7 +263,7 @@ class Pipeline {
         builder.triggerForBranch(this._scm.getBranch())
 
         // Call the generic API
-        return triggerPipelineOnEvent(builder, parameters)
+        return triggerPipelineOnEvent(builder, parameters, jobName)
     }
 
     // Triggers a pipeline on a Github PR, using the context as the trigger phrase
@@ -271,9 +271,9 @@ class Pipeline {
     //  context - The context to show on GitHub + trigger phrase that will launch the job
     // Returns:
     //  Newly created pipeline job
-    public def triggerPipelineOnGithubPRComment(String context, Map<String,Object> parameters = [:]) {
+    public def triggerPipelineOnGithubPRComment(String context, Map<String,Object> parameters = [:], String jobName = null) {
         // Create the default trigger phrase based on the context
-        return triggerPipelineOnGithubPRComment(context, null, parameters)
+        return triggerPipelineOnGithubPRComment(context, null, parameters, jobName)
     }
 
     /**
@@ -283,12 +283,12 @@ class Pipeline {
      *
      * @return Newly created job
      */
-    public def triggerPipelineOnPush(Map<String,Object> parameters = [:]) {
+    public def triggerPipelineOnPush(Map<String,Object> parameters = [:], String jobName = null) {
         if (this._scm.getScmType() == 'VSTS') {
-            return triggerPipelineOnVSTSPush(parameters)
+            return triggerPipelineOnVSTSPush(parameters, jobName)
         }
         else if (this._scm.getScmType() == 'GitHub') {
-            return triggerPipelineOnGithubPush(parameters)
+            return triggerPipelineOnGithubPush(parameters, jobName)
         }
         else {
             assert false : "NYI, unknown scm type"
@@ -300,11 +300,11 @@ class Pipeline {
     //  parameters - Parameters to pass to the pipeline on a push
     // Returns:
     //  Newly created job
-    public def triggerPipelineOnVSTSPush(Map<String,Object> parameters = [:]) {
+    public def triggerPipelineOnVSTSPush(Map<String,Object> parameters = [:], String jobName = null) {
         VSTSTriggerBuilder builder = VSTSTriggerBuilder.triggerOnCommit()
 
         // Call the generic API
-        return triggerPipelineOnEvent(builder, parameters)
+        return triggerPipelineOnEvent(builder, parameters, jobName)
     }
 
     // Triggers a pipeline on a Github Push
@@ -312,20 +312,20 @@ class Pipeline {
     //  parameters - Parameters to pass to the pipeline on a push
     // Returns:
     //  Newly created job
-    public def triggerPipelineOnGithubPush(Map<String,Object> parameters = [:]) {
+    public def triggerPipelineOnGithubPush(Map<String,Object> parameters = [:], String jobName = null) {
         GithubTriggerBuilder builder = GithubTriggerBuilder.triggerOnCommit()
 
         // Call the generic API
-        return triggerPipelineOnEvent(builder, parameters)
+        return triggerPipelineOnEvent(builder, parameters, jobName)
     }
 
     // Triggers a pipeline periodically, if changes have been made to the
     // source control in question.
-    public def triggerPipelinePeriodically(String cronString, Map<String,Object> parameters = [:]) {
+    public def triggerPipelinePeriodically(String cronString, Map<String,Object> parameters = [:], String jobName = null) {
         GenericTriggerBuilder builder = GenericTriggerBuilder.triggerPeriodically(cronString)
 
         // Call the generic API
-        return triggerPipelineOnEvent(builder, parameters)
+        return triggerPipelineOnEvent(builder, parameters, jobName)
     }
 
     /* Creates a pipeline that only triggers manually
@@ -334,11 +334,11 @@ class Pipeline {
      *
      * @return Newly created job
      */
-    public def triggerPipelineManually(Map<String,Object> parameters = [:]) {
+    public def triggerPipelineManually(Map<String,Object> parameters = [:], String jobName = null) {
         GenericTriggerBuilder builder = GenericTriggerBuilder.triggerManually()
 
         // Call the generic API
-        return triggerPipelineOnEvent(builder, parameters)
+        return triggerPipelineOnEvent(builder, parameters, jobName)
     }
 
     // Creates a pipeline job for a generic trigger event
@@ -347,13 +347,16 @@ class Pipeline {
     //  parameter - Parameter set to run the pipeline with
     // Returns
     //  Newly created pipeline job
-    public def triggerPipelineOnEvent(TriggerBuilder triggerBuilder, Map<String,Object> params = [:]) {
+    public def triggerPipelineOnEvent(TriggerBuilder triggerBuilder, Map<String,Object> params = [:], String jobName = null) {
         // Determine the job name
         // Job name is based off the parameters 
 
         def isPR = triggerBuilder.isPRTrigger()
-        def jobName = getPipelineJobName(params)
-        def fullJobName = Utilities.getFullJobName(jobName, isPR)
+        def _jobName = jobName
+        if(_jobName == null) {
+            _jobName = Pipeline.getPipelineJobName(_baseJobName, params)
+        }
+        def fullJobName = Utilities.getFullJobName(_jobName, isPR)
 
         // Create the standard pipeline job
         def newJob = createStandardPipelineJob(fullJobName, isPR, params)

--- a/src/org/dotnet/helix/HelixEvent.groovy
+++ b/src/org/dotnet/helix/HelixEvent.groovy
@@ -1,0 +1,40 @@
+package org.dotnet.helix;
+
+import java.util.UUID
+
+class HelixEvent {
+    private static String s_connectionString
+    private static String s_stagingConnectionString
+
+    static void Initialize(String eventHubConnectionString, String eventHubStagingConnectionString = null) {
+        s_connectionString = eventHubConnectionString
+        s_stagingConnectionString = eventHubStagingConnectionString
+    }
+
+    public static IHelixEventSender CreateSender(String correlationId, String workItemId) {
+        if(IsNullOrWhitespace(s_connectionString)) {
+            return s_nullSender
+        }
+        return new HelixEventSender(correlationId, workItemId, s_connectionString, s_stagingConnectionString)
+    }
+
+    public static IHelixEventSender CreateSender(String correlationId) {
+        if(IsNullOrWhitespace(s_connectionString)) {
+            return s_nullSender
+        }
+        return new HelixEventSender(correlationId, UUID.randomUUID().toString(), s_connectionString, s_stagingConnectionString)
+    }
+
+    public static IHelixEventSender CreateSender() {
+        if(IsNullOrWhitespace(s_connectionString)) {
+            return s_nullSender
+        }
+        return new HelixEventSender(UUID.randomUUID().toString(), UUID.randomUUID().toString(), s_connectionString, s_stagingConnectionString)
+    }
+
+    private static Boolean IsNullOrWhitespace(String testString) {
+        return testString == null || testString.isEmpty() || testString.trim().isEmpty()
+    }
+
+    private static IHelixEventSender s_nullSender = new NoopSender()
+}

--- a/src/org/dotnet/helix/HelixEventData.groovy
+++ b/src/org/dotnet/helix/HelixEventData.groovy
@@ -1,0 +1,28 @@
+package org.dotnet.helix;
+
+import groovy.json.*
+
+class HelixEventData {
+    String type
+    String correlationId
+    String workItemId
+    Map data
+
+    public String toJson() {
+        def eventDataMap = [:]
+        eventDataMap.Type = type
+        eventDataMap.CorrelationId = correlationId
+        eventDataMap.WorkItemId = workItemId
+        
+        data.each { prop, val ->
+            if(prop != "Properties") {
+                eventDataMap.put(prop, val)
+            }
+        }
+        if(data.Properties != null) {
+            eventDataMap.put("Properties", new JsonBuilder(data.Properties).toString())
+        }
+
+        return new JsonBuilder(eventDataMap).toString()
+    }
+}

--- a/src/org/dotnet/helix/HelixEventSender.groovy
+++ b/src/org/dotnet/helix/HelixEventSender.groovy
@@ -1,0 +1,55 @@
+package org.dotnet.helix;
+
+// ToDo: probably need to remove this and add the jars to jenkins as we don't want external dependencies
+@Grab(group='com.microsoft.azure', module='azure-eventhubs', version='0.14.5')
+
+import com.microsoft.azure.eventhubs.*
+
+class HelixEventSender implements IHelixEventSender {
+    String correlationId
+    String workItemId
+
+    final EventHubClient _sender
+    final EventHubClient _stagingSender
+    
+    public HelixEventSender(String correlationId,
+                            String workItemId,
+                            String eventHubConnectionString,
+                            String stagingEventHubConnectionString = null) {
+        this.correlationId = correlationId
+        this.workItemId = workItemId
+        _sender = EventHubClient.createFromConnectionString(eventHubConnectionString).get()
+        if(stagingEventHubConnectionString != null) {
+            _stagingSender = EventHubClient.createFromConnectionString(stagingEventHubConnectionString).get()
+        }
+    }
+    
+    String Send(HelixEventData data) {
+        if (data == null) throw new Exception("HelixEventData is null")
+        
+        data.correlationId = correlationId
+        data.workItemId = workItemId
+
+        def jsonString = ''
+        try {
+            jsonString = data.toJson()
+            EventData eventData = new EventData(data.toJson().getBytes())
+            if(_sender != null) {
+                _sender.send(eventData)
+            }
+            if(_stagingSender != null) {
+                _stagingSender.send(eventData)
+            }
+        }
+        catch(Exception e) {
+            println e.getMessage()
+            println e.getLocationText()
+            throw e
+        }
+        return jsonString
+    }
+    
+    IHelixEventSender GetForRelatedWorkItem(String workItemId) {
+        return new HelixEventSender(correlationId, workItemId, _sender, _stagingSender)
+    }
+} 

--- a/src/org/dotnet/helix/HelixTraceListener.groovy
+++ b/src/org/dotnet/helix/HelixTraceListener.groovy
@@ -1,0 +1,7 @@
+package org.dotnet.helix;
+
+class HelixTraceListener {
+//    @groovy.beans.ListenerList
+    List<HelixEvent> listeners
+    IHelixEventSender EventSender
+}

--- a/src/org/dotnet/helix/IHelixEventSender.groovy
+++ b/src/org/dotnet/helix/IHelixEventSender.groovy
@@ -1,0 +1,7 @@
+package org.dotnet.helix;
+
+interface IHelixEventSender {
+    String Send(HelixEventData data)
+    IHelixEventSender GetForRelatedWorkItem(String workItemId)
+    String correlationId
+}

--- a/src/org/dotnet/helix/NoopSender.groovy
+++ b/src/org/dotnet/helix/NoopSender.groovy
@@ -1,0 +1,15 @@
+package org.dotnet.helix;
+
+import java.util.UUID
+
+class NoopSender implements IHelixEventSender {
+    public final String correlationId
+
+    public String Send(HelixEventData data) {return ''}
+
+    public IHelixEventSender GetForRelatedWorkItem(String workItemId) {return this}
+
+    public NoopSender() { 
+        this.correlationId = new UUID(0L, 0L)
+    }
+}

--- a/vars/createSender.groovy
+++ b/vars/createSender.groovy
@@ -1,0 +1,30 @@
+import org.dotnet.helix.*
+def call(Map senderMap) {
+    return call(senderMap.correlationId, senderMap.workItemId, senderMap.credentialsIdentifier)
+}
+def call(String credentialsIdentifier) {
+    return call(null, null, credentialsIdentifier)
+}
+def call(String correlationId, String credentialsIdentifier) {
+    return call(correlationId, null, credentialsIdentifier)
+}
+
+/* Create a helix event sender which is used to send events to the endpoint specified in the
+ * credentialsIdentifier
+ */
+def call(String correlationId, String workItemId, String credentialsIdentifier) {
+    withCredentials([string(credentialsId: credentialsIdentifier, variable: 'helixEndpoint')]) {
+        HelixEvent.Initialize(env.helixEndpoint)
+        if(correlationId != null) {
+            if(workItemId != null) {
+                return HelixEvent.CreateSender(correlationId, workItemId)
+            }
+            else {
+                return HelixEvent.CreateSender(correlationId)
+            }
+        }
+        else {
+            return HelixEvent.CreateSender()
+        }
+    }
+}

--- a/vars/createSenderMap.groovy
+++ b/vars/createSenderMap.groovy
@@ -1,0 +1,17 @@
+/* Creates a "sender" Map object, which is a dictionary with these values
+ *  correlationId: value
+ *  workItemId: value
+ *  credentialsIdentifier: value
+ *  Generates new correlation and workItem id's if they are not specified'
+ */  
+def call(String credentialsIdentifier, String correlationId = null, String workItemId = null ) {
+    if(correlationId == null) {
+        correlationId = generateRandomUUID()
+    }
+    if(workItemId == null) {
+        workItemId = generateRandomUUID()
+    }
+    return Collections.synchronizedMap([correlationId: correlationId,
+                                        workItemId: workItemId,
+                                        credentialsIdentifier: credentialsIdentifier])
+}

--- a/vars/generateRandomUUID.groovy
+++ b/vars/generateRandomUUID.groovy
@@ -1,0 +1,7 @@
+import java.util.UUID
+
+/* Return a random UUID string
+ */
+def call() {
+    return UUID.randomUUID().toString()
+}

--- a/vars/getBuildNumber.groovy
+++ b/vars/getBuildNumber.groovy
@@ -1,0 +1,11 @@
+/**
+  * Retrieves formatted official build number.
+  * Depends on the Version Number Plugin (https://wiki.jenkins.io/display/JENKINS/Version+Number+Plugin)
+  * to provide these variable values
+  */
+def call() {
+    // The VersionNumber method takes a format string, and returns a conforming build number
+    def versionNumber = VersionNumber('${BUILD_YEAR}${BUILD_MONTH, XX}${BUILD_DAY, XX}-${BUILDS_TODAY, XX}')
+    assert versionNumber != null : "Version number is not a valid format, is the 'Version Number Plugin' installed?"
+    return versionNumber
+}

--- a/vars/getSenderMap.groovy
+++ b/vars/getSenderMap.groovy
@@ -1,0 +1,18 @@
+import org.dotnet.helix.*
+
+def call(String credentialsIdentifier) {
+    return call(null, null, credentialsIdentifier)
+}
+
+def call(String correlationId, String credentialsIdentifier) {
+    return call(correlationId, null, credentialsIdentifier)
+}
+
+def call(String correlationId, String workItemId, String credentialsIdentifier) {
+    withCredentials([string(credentialsId: credentialsIdentifier, variable: 'HelixEndpoint')]) {
+        def sender = createSender(correlationId, workItemId, credentialsIdentifier)
+        return [CorrelationId: sender.CorrelationId,
+                WorkItemId: sender.WorkItemId,
+                CredentialsIdentifier: credentialsIdentifier]
+    }
+}

--- a/vars/sendEvent.groovy
+++ b/vars/sendEvent.groovy
@@ -1,0 +1,26 @@
+import org.dotnet.helix.*
+
+def call(String type, Map data, Map senderMap, Integer maxRetries = 3, Integer waitTimeInMilliseconds = 1000) {
+    def sender = createSender(senderMap)
+    def eventData = new HelixEventData()
+    eventData.type = type
+    eventData.data = data
+
+    return Send(sender, eventData, 0, maxRetries, waitTimeInMilliseconds)
+}
+
+/**
+ *  Send event data with retry logic, if not succesful after 'maxRetries', ignore the failure and continue 
+ */
+def Send(IHelixEventSender sender, HelixEventData eventData, Integer attempt, Integer maxRetries, Integer waitTimeInMilliseconds) {
+    try {
+        return sender.Send(eventData)
+    }
+    catch(Exception) {
+        if(attempt < maxRetries) {
+            println "Send event failed, will retry in ${waitTimeInMilliseconds} ms (retry ${attempt + 1} / ${maxRetries})"
+            Thread.sleep(waitTimeInMilliseconds)
+            return Send(data, attempt + 1, maxRetries)
+        }
+    }
+}

--- a/vars/simpleDockerNode.groovy
+++ b/vars/simpleDockerNode.groovy
@@ -46,6 +46,22 @@ def call(String dockerImageName, String hostVersion, Closure body) {
 //  timeoutInMinutes - Timeout in minutes for the body
 //  body - Closure, see example
 def call(String dockerImageName, String hostVersion, int timeoutInMinutes, Closure body) {
+    call(dockerImageName, hostVersion, timeoutInMinutes, '', body)
+}
+
+// Runs a set of functionality on the default node
+// that supports docker.
+// Parameters:
+//  dockerImageName - Docker image to use
+//  hostVersion - Host VM version.  See Agents.getDockerMachineAffinity for explanation.
+//  timeoutInMinutes - Timeout in minutes for the body
+// dockerArgs - additional docker parameters for the docker node
+//  body - Closure, see example
+def call(String dockerImageName, String hostVersion, String dockerArgs, Closure body) {
+    call(dockerImageName, hostVersion, Constants.DEFAULT_PIPELINE_TIMEOUT, dockerArgs, body)
+}
+
+def call(String dockerImageName, String hostVersion, int timeoutInMinutes, String dockerArgs, Closure body) {
     node (Agents.getDockerAgentLabel(hostVersion)) {
         timestamps {
             timeout(timeoutInMinutes) {
@@ -60,7 +76,7 @@ def call(String dockerImageName, String hostVersion, int timeoutInMinutes, Closu
                 // users in our container.  This bug is filed as https://issues.jenkins-ci.org/browse/JENKINS-38438.
                 // In the meantime, we can pass -u to the inside() step which will append to the command line and
                 // override the original -u.
-                dockerImage.inside('-u 0:0') {
+                dockerImage.inside('-u 0:0 ' + dockerArgs) {
                     try {
                         // Make the log folder
                         makeLogFolder()


### PR DESCRIPTION
- Update Pipeline.groovy to support `getValidJobNameString` as a static method so that we can later derive the job name.  I made a separate change which made this irrelevant where I explicitly specify a job name rather than letting it derive.  The result is that being able to determine the job name via a static method is not necessary.  I left this change in my PR, but I'm ok with reverting it if it's a concern.
- Update Pipeline.groovy to allow you to explicitly specify job names when creating triggers
- Add Helix event logic so that we can send Helix events.  I added the Helix event logic here (rather than BuildTools) so that we can send events from anywhere during the pipeline
- Update simpleDockerNode so that we can pass arguments to the docker command