### PR TITLE
Use explicit patterns when cleaning

### DIFF
--- a/src/jobs/generation/Utilities.groovy
+++ b/src/jobs/generation/Utilities.groovy
@@ -311,6 +311,8 @@ class Utilities {
                     cleanWhenFailure(true)
                     cleanWhenAborted(true)
                     cleanWhenUnstable(true)
+                    includePattern('**/src/**')
+                    deleteDirectories(true)
                 }
             }
 

--- a/vars/simpleDockerNode.groovy
+++ b/vars/simpleDockerNode.groovy
@@ -98,7 +98,7 @@ def call(String dockerImageName, String hostVersion, int timeoutInMinutes, Strin
                         echo "Cleaning workspace ${WORKSPACE}"
                         sh 'rm -rf *'
                         // Use the workspace cleaner now.
-                        step([$class: 'WsCleanup'])
+                        cleanWs deleteDirs: true, patterns: [[pattern: '**/*', type: 'INCLUDE']]
                     }
                 }
             }

--- a/vars/simpleNode.groovy
+++ b/vars/simpleNode.groovy
@@ -17,7 +17,7 @@ import org.dotnet.ci.util.Constants
 def call(String label, int timeoutInMinutes, Closure body) {
     node (label) {
         // Clean.  Currently processes are killed at the end of the node block, but we don't have an easy way to run the cleanup
-        // after the node block exits currently.  Cleaning at the start should be sufficient.
+        // after the node block exits.  Cleaning at the start should be sufficient.
         cleanWs deleteDirs: true, patterns: [[pattern: '**/*', type: 'INCLUDE']]
         // Make the log folder
         makeLogFolder()

--- a/vars/simpleNode.groovy
+++ b/vars/simpleNode.groovy
@@ -18,7 +18,7 @@ def call(String label, int timeoutInMinutes, Closure body) {
     node (label) {
         // Clean.  Currently processes are killed at the end of the node block, but we don't have an easy way to run the cleanup
         // after the node block exits currently.  Cleaning at the start should be sufficient.
-        step([$class: 'WsCleanup'])
+        cleanWs deleteDirs: true, patterns: [[pattern: '**/*', type: 'INCLUDE']]
         // Make the log folder
         makeLogFolder()
         // Wrap in a try finally that cleans up the workspace
@@ -47,7 +47,7 @@ def call(String label, int timeoutInMinutes, Closure body) {
                     // For now, kill the most common culprit (return status instead of failing if the process wasn't found
                     bat script: 'taskkill /F /IM VBCSCompiler.exe', returnStatus: true
                 }
-                step([$class: 'WsCleanup'])
+                cleanWs deleteDirs: true, patterns: [[pattern: '**/*', type: 'INCLUDE']]
             }
             catch (e) {
                 echo "Some files could not be cleaned up because of running processes.  These processes will be killed immediately and cleanup will happen before the node upon node-reuse"


### PR DESCRIPTION
This avoids async cleanup, which is a problem with the Helix agents plugin (since nodes don't get cleaned before reassignment)