### PR TITLE
Add script that removes offline azure nodes not taken manually offline

### DIFF
--- a/scripts/remove_offline_nodes.groovy
+++ b/scripts/remove_offline_nodes.groovy
@@ -1,0 +1,21 @@
+// Removes offline nodes from AzureVMAgents that weren't taken offline for user reasons
+
+import com.microsoft.azure.vmagent.AzureVMAgent 
+
+def nodes = Jenkins.instance.getNodes()
+
+nodes.each { node ->
+  if (node instanceof AzureVMAgent) {
+    if (node.getComputer() != null) {
+      if (node.getComputer().isTemporarilyOffline()) {
+        def cause = node.getComputer().getOfflineCause()
+        if (!(cause instanceof hudson.slaves.OfflineCause.UserCause)) {
+          println "Removing " + node.getComputer().getName() + " "
+          Jenkins.instance.removeNode(node)
+        }
+      }
+    }
+  }
+}
+
+return true


### PR DESCRIPTION
This works around a current bug that sometimes leaves an agent in Jenkins without being cleaned up if deletion from azure fails.  This bug is fixed in a currently unreleased Azure VM Agents version.