### PR TITLE
update F# branch definitions

### DIFF
--- a/data/repolist.txt
+++ b/data/repolist.txt
@@ -159,8 +159,8 @@ Microsoft/xunit-performance branch=master server=dotnet-ci
 Microsoft/xunit-performance branch=citest server=dotnet-ci
 Microsoft/Vipr branch=master server=dotnet-ci
 Microsoft/visualfsharp branch=master server=dotnet-ci2
-Microsoft/visualfsharp branch=dev15.5 server=dotnet-ci2
 Microsoft/visualfsharp branch=dev15.6 server=dotnet-ci2
+Microsoft/visualfsharp branch=dev15.7 server=dotnet-ci2
 Microsoft/PartsUnlimited branch=master server=dotnet-ci
 dotnet/templating branch=master server=dotnet-ci
 dotnet/templating branch=rel/2.1.0-preview1 server=dotnet-ci


### PR DESCRIPTION
The dev15.5 branch is no longer needed and 15.7 was just added.