### PR TITLE
Include .NET framework Docker repo

### DIFF
--- a/data/repolist.txt
+++ b/data/repolist.txt
@@ -150,6 +150,7 @@ Microsoft/ChakraCore branch=builtins server=dotnet-ci2
 Microsoft/ConcordExtensibilitySamples branch=master server=dotnet-ci
 Microsoft/dotnet-apiport branch=master server=dotnet-ci2
 Microsoft/dotnet-apiport branch=dev server=dotnet-ci2
+Microsoft/dotnet-framework-docker branch=master server=dotnet-ci
 Microsoft/MIEngine branch=master server=dotnet-ci
 Microsoft/msbuild branch=master server=dotnet-ci2
 Microsoft/msbuild branch=vs15.4 server=dotnet-ci2


### PR DESCRIPTION
Enable CI for Microsoft/dotnet-framework-docker.

Refer to https://github.com/Microsoft/dotnet-framework-docker/issues/66