### PR TITLE
Update MSBuild branches (15.6, 15.7)

### DIFF
--- a/data/repolist.txt
+++ b/data/repolist.txt
@@ -172,8 +172,9 @@ Microsoft/dotnet-apiport branch=dev server=dotnet-ci2
 Microsoft/dotnet-framework-docker branch=master server=dotnet-ci
 Microsoft/MIEngine branch=master server=dotnet-ci
 Microsoft/msbuild branch=master server=dotnet-ci2
-Microsoft/msbuild branch=vs15.4 server=dotnet-ci2
 Microsoft/msbuild branch=vs15.5 server=dotnet-ci2
+Microsoft/msbuild branch=vs15.6 server=dotnet-ci2
+Microsoft/msbuild branch=vs15.7 server=dotnet-ci2
 Microsoft/msbuild branch=exp/update-toolset server=dotnet-ci2
 Microsoft/TypeScript branch=master server=dotnet-ci2
 Microsoft/xunit-performance branch=master server=dotnet-ci


### PR DESCRIPTION
Add 15.6 (current lock down) and 15.7 (product construction lock down for Core 2.1).