### PR TITLE
Adding the release/2.1.3xx branches for cli-migrate and clicommandlineparser

### DIFF
--- a/data/repolist.txt
+++ b/data/repolist.txt
@@ -34,8 +34,10 @@ dotnet/core-sdk branch=dev/repo-refactoring server=dotnet-ci
 dotnet/toolset branch=dev/release/2.0 server=dotnet-ci
 dotnet/toolset branch=dev/repo-refactoring server=dotnet-ci
 dotnet/CliCommandLineParser branch=master server=dotnet-ci
+dotnet/CliCommandLineParser branch=release/2.1.3xx server=dotnet-ci
 dotnet/xliff-tasks branch=master server=dotnet-ci
 dotnet/cli-migrate branch=master server=dotnet-ci
+dotnet/cli-migrate branch=release/2.1.3xx server=dotnet-ci
 dotnet/dotnet-cli-archiver branch=master server=dotnet-ci
 dotnet/core-setup branch=master server=dotnet-ci
 dotnet/core-setup branch=master server=dotnet-ci3 definitionScript=buildpipeline/pipelinejobs.groovy


### PR DESCRIPTION
FYI. @mmitche 