### PR TITLE
Fix repository name

### DIFF
--- a/data/repolist.txt
+++ b/data/repolist.txt
@@ -78,7 +78,7 @@ dotnet/corefx branch=release/2.1 server=dotnet-ci
 dotnet/corefx branch=release/2.1 server=dotnet-ci3 definitionScript=buildpipeline/pipelinejobs.groovy
 dotnet/corefxlab branch=master server=dotnet-ci
 dotnet/corert branch=master server=dotnet-ci
-dotnet/dotnet-dotnet-buildtools-prereqs-docker branch=master server=dotnet-ci
+dotnet/dotnet-buildtools-prereqs-docker branch=master server=dotnet-ci
 dotnet/docker-tools branch=master server=dotnet-ci
 dotnet/dotnet-docker branch=master server=dotnet-ci
 dotnet/dotnet-docker-nightly branch=master server=dotnet-ci


### PR DESCRIPTION
Fix typo in repository name `dotnet-buildtools-prereqs-docker`.

Refer to https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/4