### PR TITLE
Allow an explicit label name for setMachineAffinity

### DIFF
--- a/src/jobs/generation/Utilities.groovy
+++ b/src/jobs/generation/Utilities.groovy
@@ -157,17 +157,26 @@ class Utilities {
         return bootstrapRidMap.get(os, null)
     }
     
-    
+    /**
+     * Given the direct name of a label, set the machine affinity for a job.  This override is useful for Helix queues
+     *
+     * @param job Job to set affinity for
+     * @param labelName Label to set the job to.  THis is useful for helix.
+     */
+    def static setMachineAffinity(def job, String labelName) {
+        job.with {
+            label(labelName)
+        }
+    }
 
     /**
      * Given the name of an OS, set the nodes that this job runs on.
      *
      * @param job Job to set affinity for
      * @param osName Name of OS to to run on.
-     * @param version Optional version of the image.  This version can be the date potentially followed
-     *                by .1, .2, etc. or it could be a static image version (like a perf label).
+     * @param version Version of the image.
      */
-    def static setMachineAffinity(def job, String osName, String version = '') {
+    def static setMachineAffinity(def job, String osName, String version) {
         String machineLabel = Agents.getAgentLabel(osName, version)
         job.with {
             label(machineLabel)

--- a/tests/pipeline/pipeline-tests.groovy
+++ b/tests/pipeline/pipeline-tests.groovy
@@ -72,6 +72,14 @@ stage ('Run Tests') {
                 }
             },
 
+            "simpleNode - Windows.10.Amd64.ClientRS3.DevEx.Open" : {
+                timeout (60) {
+                    simpleNode('Windows.10.Amd64.ClientRS3.DevEx.Open') {
+                        checkoutRepo()
+                    }
+                }
+            },
+
             // Test that simple nodes work, of various types
             "simpleNode - custom timeout" : {
                 timeout (60) {


### PR DESCRIPTION
Useful for Helix queues, which don't have versions in the agents map.  To avoid conflicting overrides, remove optional parameter to the original setMachineAffinity.
Add a test for new Helix Windows.10.Amd64.ClientRS3.DevEx.Open queue