### PR TITLE
Remove roslyn constraints branch from repolist.txt

### DIFF
--- a/data/repolist.txt
+++ b/data/repolist.txt
@@ -113,7 +113,6 @@ dotnet/roslyn branch=dev15.7.x-vs-deps server=dotnet-ci
 dotnet/roslyn branch=microupdate server=dotnet-ci
 dotnet/roslyn branch=features/codecov server=dotnet-ci
 dotnet/roslyn branch=features/compiler server=dotnet-ci
-dotnet/roslyn branch=features/constraints server=dotnet-ci
 dotnet/roslyn branch=features/range server=dotnet-ci
 dotnet/roslyn branch=features/DefaultInterfaceImplementation server=dotnet-ci
 dotnet/roslyn branch=features/editorconfig-in-compiler server=dotnet-ci


### PR DESCRIPTION
Branch was already merged. No need to keep this around.