### PR TITLE
Add ubuntu1404-20180321 with lldb-3.6 for CoreCLR.

### DIFF
--- a/management/nodes/Images.csv
+++ b/management/nodes/Images.csv
@@ -32,6 +32,7 @@ ubuntu1404-20170109,ubuntu1404-20170109,Linux,system,Microsoft.Compute/Images/do
 ubuntu1404-20170118,ubuntu1404-20170118,Linux,system,Microsoft.Compute/Images/dotnetci/ubuntu1404-20170829-osDisk.9dfcc9eb-95b6-453e-adbf-e284e1d8205a.vhd,All,./startupScripts/ubuntu1404-20170118.sh,/mnt/j
 ubuntu1404-20170821,ubuntu1404-20170821,Linux,system,Microsoft.Compute/Images/dotnetci/ubuntu1404-20170821-osDisk.715042c0-8f22-4a7d-9c64-23463fa4bf7a.vhd,All,./startupScripts/ubuntu1404-20170821.sh,/mnt/j
 ubuntu1404-20170925,ubuntu1404-20170925,Linux,system,Microsoft.Compute/Images/dotnetci/ubuntu1404-20170925-osDisk.e9bb0d99-38ce-4463-b4e2-4777af29c70e.vhd,All,./startupScripts/ubuntu1404-20170925.sh,/mnt/j
+ubuntu1404-20180321,ubuntu1404-20180321,Linux,system,Microsoft.Compute/Images/dotnetci/ubuntu1404-20180321-osDisk.66dd63ee-d57e-4f03-902c-9fec9bee8840.vhd,All,./startupScripts/ubuntu1404-20180321.sh,/mnt/j
 ubuntu1604-20170216,ubuntu1604-20170216,Linux,system,Microsoft.Compute/Images/dotnetci/ubuntu1604-20170830-osDisk.ca156cab-c57e-45fd-b980-57199ac0e78a.vhd,All,./startupScripts/ubuntu1604-20170216.sh,/mnt/j
 ubuntu1604-20170216-outer,ubuntu1604-20170216-outer,Linux,system,Microsoft.Compute/Images/dotnetci/ubuntu1604-20170830-osDisk.ca156cab-c57e-45fd-b980-57199ac0e78a.vhd,All,./startupScripts/ubuntu1604-20170216-outer.sh,/mnt/j
 ubuntu1604-20170526,ubuntu1604-20170526,Linux,system,Microsoft.Compute/Images/dotnetci/ubuntu1604-20170906-osDisk.a4a70718-78cb-49be-b8f3-ffb1ec7fcbb6.vhd,All,./startupScripts/ubuntu1604-20170526.sh,/mnt/j

--- a/management/nodes/startupScripts/ubuntu1404-20170925.sh
+++ b/management/nodes/startupScripts/ubuntu1404-20170925.sh
@@ -1,0 +1,16 @@
+# Check that Azure's temporary storage was mounted correctly
+if ! mountpoint -q "/mnt"; then
+        echo "Azure's tmp storage not mounted"
+	exit 1
+fi
+
+# Make the /mnt folder writeable
+chmod 777 /mnt/
+
+# Restart docker since now the mnt drive is writeable, then ensure that the daemon is running properly with a hello-world
+service docker restart
+docker run hello-world
+if [ $? -ne 0 ]
+then
+    exit 1
+fi

--- a/management/nodes/startupScripts/ubuntu1404-20180321.sh
+++ b/management/nodes/startupScripts/ubuntu1404-20180321.sh
@@ -1,0 +1,16 @@
+# Check that Azure's temporary storage was mounted correctly
+if ! mountpoint -q "/mnt"; then
+        echo "Azure's tmp storage not mounted"
+	exit 1
+fi
+
+# Make the /mnt folder writeable
+chmod 777 /mnt/
+
+# Restart docker since now the mnt drive is writeable, then ensure that the daemon is running properly with a hello-world
+service docker restart
+docker run hello-world
+if [ $? -ne 0 ]
+then
+    exit 1
+fi

--- a/src/org/dotnet/ci/util/Agents.groovy
+++ b/src/org/dotnet/ci/util/Agents.groovy
@@ -63,6 +63,8 @@ class Agents {
                                 '20170821':'ubuntu1404-20170821',
                                 // 20170821 + clang 3.9
                                 '20170925':'ubuntu1404-20170925',
+                                // 20170925 + lldb 3.6
+                                '20180321':'ubuntu1404-20180321',
                                 // Contains Mono 5.0.1
                                 'arm-cross-latest':'ubuntu1404-20170120',
                                 // Contains the rootfs setup for arm64 builds.
@@ -74,7 +76,7 @@ class Agents {
                                 // Image installing the latest mono-devel
                                 'latest-mono-devel':'ubuntu1404-20160211-1-latest-mono',
                                 // Latest auto image.
-                                'latest':'ubuntu1404-20170925',
+                                'latest':'ubuntu1404-20180321',
                                 // For outerloop runs.
                                 'outer-latest':'ubuntu1404-20170925-outer',
                                 // For internal Ubuntu runs


### PR DESCRIPTION
Also add startup script for ubuntu1404-20170925 since it looks like it got missed.  Verified that the CoreCLR PR that requires lldb-3.6 builds on this and building CoreFX now to make sure lldb-3.9 doesn't conflict.