### PR TITLE
Use more descriptive/unique keys in task and results map

### DIFF
--- a/tests/pipeline/pipeline-tests.groovy
+++ b/tests/pipeline/pipeline-tests.groovy
@@ -261,7 +261,7 @@ stage ('Run Tests') {
         <TargetQueues>Windows.10.Amd64.Open,Windows.10.Amd64.Open</TargetQueues>
         <HelixLogFolder>\$(MSBuildThisFileDirectory)</HelixLogFolder>
         <HelixCorrelationInfoFileName>job-info.json</HelixCorrelationInfoFileName>
-        <HelixJobProperties>{ "architecture":"x86", "configuration":"Release", operatingSystem": "pizza" }</HelixJobProperties>
+        <HelixJobProperties>{ "architecture":"x86", "configuration":"Release", "operatingSystem": "pizza" }</HelixJobProperties>
         <ArchivesRoot>\$(MSBuildThisFileDirectory)</ArchivesRoot>
     </PropertyGroup>
     <Target Name="Build" DependsOnTargets="HelixCloudBuild"/>

--- a/tests/pipeline/pipeline-tests.groovy
+++ b/tests/pipeline/pipeline-tests.groovy
@@ -258,7 +258,7 @@ stage ('Run Tests') {
         <HelixSource>${helixSource}</HelixSource>
         <BuildMoniker>${helixBuild}</BuildMoniker>
         <HelixCreator>${helixCreator}</HelixCreator>
-        <TargetQueues>Windows.10.Amd64.Open,Windows.10.Amd64.Open</TargetQueues>
+        <TargetQueues>Windows.10.Amd64.Open</TargetQueues>
         <HelixLogFolder>\$(MSBuildThisFileDirectory)</HelixLogFolder>
         <HelixCorrelationInfoFileName>job-info.json</HelixCorrelationInfoFileName>
         <HelixJobProperties>{ "architecture":"x86", "configuration":"Release", "operatingSystem": "pizza" }</HelixJobProperties>
@@ -327,7 +327,7 @@ stage ('Run Tests') {
         <TargetQueues>Windows.10.Amd64.Open</TargetQueues>
         <HelixLogFolder>\$(MSBuildThisFileDirectory)</HelixLogFolder>
         <HelixCorrelationInfoFileName>job-info.json</HelixCorrelationInfoFileName>
-        <HelixJobProperties>{ "operatingSystem": "pizza" }</HelixJobProperties>
+        <HelixJobProperties>{ "architecture":"x64", "configuration":"Debug", "operatingSystem": "pizza" }</HelixJobProperties>
         <ArchivesRoot>\$(MSBuildThisFileDirectory)</ArchivesRoot>
     </PropertyGroup>
     <Target Name="Build" DependsOnTargets="HelixCloudBuild"/>

--- a/tests/pipeline/pipeline-tests.groovy
+++ b/tests/pipeline/pipeline-tests.groovy
@@ -261,7 +261,7 @@ stage ('Run Tests') {
         <TargetQueues>Windows.10.Amd64.Open</TargetQueues>
         <HelixLogFolder>\$(MSBuildThisFileDirectory)</HelixLogFolder>
         <HelixCorrelationInfoFileName>job-info.json</HelixCorrelationInfoFileName>
-        <HelixJobProperties>{ "operatingSystem": "pizza" }</HelixJobProperties>
+        <HelixJobProperties>{ "architecture":"x86", "configuration":"Release", operatingSystem": "pizza" }</HelixJobProperties>
         <ArchivesRoot>\$(MSBuildThisFileDirectory)</ArchivesRoot>
     </PropertyGroup>
     <Target Name="Build" DependsOnTargets="HelixCloudBuild"/>

--- a/tests/pipeline/pipeline-tests.groovy
+++ b/tests/pipeline/pipeline-tests.groovy
@@ -258,7 +258,7 @@ stage ('Run Tests') {
         <HelixSource>${helixSource}</HelixSource>
         <BuildMoniker>${helixBuild}</BuildMoniker>
         <HelixCreator>${helixCreator}</HelixCreator>
-        <TargetQueues>Windows.10.Amd64.Open</TargetQueues>
+        <TargetQueues>Windows.10.Amd64.Open,Windows.10.Amd64.Open</TargetQueues>
         <HelixLogFolder>\$(MSBuildThisFileDirectory)</HelixLogFolder>
         <HelixCorrelationInfoFileName>job-info.json</HelixCorrelationInfoFileName>
         <HelixJobProperties>{ "architecture":"x86", "configuration":"Release", operatingSystem": "pizza" }</HelixJobProperties>

--- a/vars/waitForHelixRuns.groovy
+++ b/vars/waitForHelixRuns.groovy
@@ -48,13 +48,13 @@ def call (def helixRunsBlob, String prStatusPrefix) {
                     } else {
                         helixRunKeys[correlationId] = queueId
                     }
-                    
+
                     if (statusContent.Properties != null) {
                         if (statusContent.Properties.architecture != null) {
-                            helixRunKeys[correlationId] += " ${statusContent.Properties.architecture}"
+                            helixRunKeys[correlationId] += " - ${statusContent.Properties.architecture}"
                         }
                         if (statusContent.Properties.configuration != null) {
-                            helixRunKeys[correlationId] += " ${statusContent.Properties.configuration}"
+                            helixRunKeys[correlationId] += " - ${statusContent.Properties.configuration}"
                         }
                     }
 

--- a/vars/waitForHelixRuns.groovy
+++ b/vars/waitForHelixRuns.groovy
@@ -76,7 +76,7 @@ def call (def helixRunsBlob, String prStatusPrefix) {
         }
     }
     helixRunKeys = tempRunKeys
-    mcUrlMap[helixRunKeys[correlationId]] = mcResultsUrl
+    mcUrlMap[helixRunKeys[correlationId]] = correlationIdUrlMap[correlationId]
     addSummaryLink('Test Run Results', mcUrlMap)
 
     for (int i = 0; i < helixRunsBlob.size(); i++) {

--- a/vars/waitForHelixRuns.groovy
+++ b/vars/waitForHelixRuns.groovy
@@ -21,6 +21,7 @@ def call (def helixRunsBlob, String prStatusPrefix) {
     // Parallel stages that wait for the runs.
     def helixRunTasks = [:]
     def mcUrlMap = [:]
+    def helixRunKeys = [:]
     def failedRunMap = [:]
     def passed = true
 
@@ -38,7 +39,26 @@ def call (def helixRunsBlob, String prStatusPrefix) {
                     assert statusResponse.content != null
                     def statusContent = (new JsonSlurperClassic()).parseText(statusResponse.content)
                     def mcResultsUrl = "https://mc.dot.net/#/user/${getEncodedUrl(statusContent.Creator)}/${getEncodedUrl(statusContent.Source)}/${getEncodedUrl(statusContent.Type)}/${getEncodedUrl(statusContent.Build)}"
-                    mcUrlMap[queueId] = mcResultsUrl
+
+                    // Attempt to use the property bag (arch and config), if available, to make the helix keys to the task map more descriptive.
+                    // If we cannot make it unique, then append the correlation id
+                    if (helixRunKeys[correlationId] != null) {
+                        // Already exists.  Append correlation ID
+                        helixRunKeys[correlationId] = "${queueId} - ${correlationId}"
+                    } else {
+                        helixRunKeys[correlationId] = queueId
+                    }
+                    
+                    if (statusContent.Properties != null) {
+                        if (statusContent.Properties.architecture != null) {
+                            helixRunKeys[correlationId] += " ${statusContent.Properties.architecture}"
+                        }
+                        if (statusContent.Properties.configuration != null) {
+                            helixRunKeys[correlationId] += " ${statusContent.Properties.configuration}"
+                        }
+                    }
+
+                    mcUrlMap[helixRunKeys[correlationId]] = mcResultsUrl
                 }
                 catch (Exception ex) {
                     println(ex.toString());
@@ -57,7 +77,7 @@ def call (def helixRunsBlob, String prStatusPrefix) {
         def queueId = currentRun['QueueId']
         def correlationId = currentRun['CorrelationId']
 
-        helixRunTasks[queueId] = {
+        helixRunTasks[helixRunKeys[correlationId]] = {
             // State to minimize status updates.
             // 0 = Not yet updated/started
             // 1 = Pending updated
@@ -131,7 +151,7 @@ def call (def helixRunsBlob, String prStatusPrefix) {
                             if (workItemStatus.fail) {
                                 resultValue = "FAILURE"
                                 passed = false
-                                failedRunMap[queueId] = mcResultsUrl
+                                failedRunMap[helixRunKeys[correlationId]] = mcResultsUrl
                                 subMessage = "Catastrophic Failure: ${workItemStatus.fail} work items failed"
                             } else if (workItemStatus.none) {
                                 resultValue = "PROCESSING XUNIT"
@@ -156,7 +176,7 @@ def call (def helixRunsBlob, String prStatusPrefix) {
                                 if (failedTests > 0) {
                                     resultValue = "FAILURE"
                                     passed = false
-                                    failedRunMap[queueId] = mcResultsUrl
+                                    failedRunMap[helixRunKeys[correlationId]] = mcResultsUrl
                                     subMessage = "Failed ${failedTests}/${totalTests} (${skippedTests} skipped)"
                                 }
                                 else {

--- a/vars/waitForHelixRuns.groovy
+++ b/vars/waitForHelixRuns.groovy
@@ -42,7 +42,6 @@ def call (def helixRunsBlob, String prStatusPrefix) {
 
                     // Attempt to use the property bag (arch and config), if available, to make the helix keys to the task map more descriptive.
                     helixRunKeys[correlationId] = queueId
-                    mcUrlMap[correlationId] = mcResultsUrl
 
                     if (statusContent.Properties != null) {
                         if (statusContent.Properties.architecture != null) {
@@ -55,6 +54,9 @@ def call (def helixRunsBlob, String prStatusPrefix) {
 
                     // Append correlatio id
                     helixRunKeys[correlationId] += " (${correlationId})"
+
+                    // Set the results url
+                    mcUrlMap[helixRunKeys[correlationId]] = mcResultsUrl
                 }
                 catch (Exception ex) {
                     println(ex.toString());

--- a/vars/waitForHelixRuns.groovy
+++ b/vars/waitForHelixRuns.groovy
@@ -41,13 +41,7 @@ def call (def helixRunsBlob, String prStatusPrefix) {
                     def mcResultsUrl = "https://mc.dot.net/#/user/${getEncodedUrl(statusContent.Creator)}/${getEncodedUrl(statusContent.Source)}/${getEncodedUrl(statusContent.Type)}/${getEncodedUrl(statusContent.Build)}"
 
                     // Attempt to use the property bag (arch and config), if available, to make the helix keys to the task map more descriptive.
-                    // If we cannot make it unique, then append the correlation id
-                    if (helixRunKeys[correlationId] != null) {
-                        // Already exists.  Append correlation ID
-                        helixRunKeys[correlationId] = "${queueId} - ${correlationId}"
-                    } else {
-                        helixRunKeys[correlationId] = queueId
-                    }
+                    helixRunKeys[correlationId] = queueId
 
                     if (statusContent.Properties != null) {
                         if (statusContent.Properties.architecture != null) {
@@ -56,6 +50,13 @@ def call (def helixRunsBlob, String prStatusPrefix) {
                         if (statusContent.Properties.configuration != null) {
                             helixRunKeys[correlationId] += " - ${statusContent.Properties.configuration}"
                         }
+                    }
+
+                    // Find a dupe if one exists.  If it exists, append the correlation id.
+                    def dupe = helixRunKeys.find { it.value == helixRunKeys[correlationId] }
+                    if (dupe != null) {
+                        helixRunKeys[correlationId] += " (${correlationId})"
+                        helixRunKeys[dupe.key] += " (${correlationId})"
                     }
 
                     mcUrlMap[helixRunKeys[correlationId]] = mcResultsUrl

--- a/vars/waitForHelixRuns.groovy
+++ b/vars/waitForHelixRuns.groovy
@@ -52,7 +52,7 @@ def call (def helixRunsBlob, String prStatusPrefix) {
                         }
                     }
 
-                    // Append correlatio id
+                    // Append correlation id
                     helixRunKeys[correlationId] += " (${correlationId})"
 
                     // Set the results url


### PR DESCRIPTION
If multiple correlation ids submit to the same queue, we won't track all of them because we key the tasks and results off of queue id.  Instead, generate a unique key in the map by utilizing the property bad as well as the correlation id as a last resort.