### PR TITLE
Remove Helix agents in node cleanup script

### DIFF
--- a/scripts/remove_offline_nodes.groovy
+++ b/scripts/remove_offline_nodes.groovy
@@ -1,16 +1,18 @@
 // Removes offline nodes from AzureVMAgents that weren't taken offline for user reasons
 
 import jenkins.model.Jenkins
-import com.microsoft.azure.vmagent.AzureVMAgent 
+import com.microsoft.azure.vmagent.AzureVMAgent
+import com.microsoft.helix.helixagents.HelixAgent
 
 def nodes = Jenkins.instance.getNodes()
 
 nodes.each { node ->
-  if (node instanceof AzureVMAgent) {
+  if (node instanceof AzureVMAgent || node instanceof HelixAgent) {
     if (node.getComputer() != null) {
       if (node.getComputer().isTemporarilyOffline()) {
         def cause = node.getComputer().getOfflineCause()
-        if (!(cause instanceof hudson.slaves.OfflineCause.UserCause)) {
+        if (!(cause instanceof hudson.slaves.OfflineCause.UserCause) && 
+            (!(node instanceof HelixAgent) || !(cause instanceof hudson.slaves.OfflineCause.SimpleOfflineCause))) {
           println "Removing " + node.getComputer().getName() + " "
           Jenkins.instance.removeNode(node)
         }

--- a/src/jobs/generation/RootGenerator.groovy
+++ b/src/jobs/generation/RootGenerator.groovy
@@ -448,9 +448,9 @@ job('node_cleaner') {
         }
     }
 
-    // Run hourly
+    // Run every hour
     triggers {
-        cron('@daily')
+        cron('@hourly')
     }
 
     // We stream from the workspace since in the groovy 2.0 plugin, the scripts


### PR DESCRIPTION
Sometimes Jenkins takes agents offline for no apparent reasnon.  We remove these agents periodically.  Add Helix agents to the list of agents to remove