### PR TITLE
Add RTM branches for testfx, & vstest in dotnet-ci

### DIFF
--- a/data/repolist.txt
+++ b/data/repolist.txt
@@ -232,10 +232,12 @@ Microsoft/vstest branch=master server=dotnet-ci
 Microsoft/vstest branch=future server=dotnet-ci
 Microsoft/vstest branch=rel/15.6 server=dotnet-ci
 Microsoft/vstest branch=perf-improvements server=dotnet-ci
+Microsoft/vstest branch=rel/15.7 server=dotnet-ci
 mmitche/coreclr branch=dev/pipeline server=dotnet-ci3 definitionScript=buildpipeline/pipelinejobs.groovy
 adiaaida/coreclr branch=dev/pipeline server=dotnet-ci3 definitionScript=buildpipeline/pipelinejobs.groovy
 dotnet/coreclr branch=master server=dotnet-ci2 definitionScript=buildpipeline/perf_pipelinejobs.groovy
 Microsoft/testfx branch=master server=dotnet-ci
+Microsoft/testfx branch=1.2.1 server=dotnet-ci
 sbomer/coreclr branch=master server=dotnet-ci3 definitionScript=buildpipeline/pipelinejobs.groovy
 # Tests for pipelines
 dotnet/dotnet-ci branch=master definitionScript=tests/pipeline/tests.groovy server=dotnet-ci3 subFolder=pipelineTests


### PR DESCRIPTION
TestFx [1.2.1](https://github.com/Microsoft/testfx/tree/1.2.1)
Vstest [15.7](https://github.com/Microsoft/vstest/tree/rel/15.7)