### PR TITLE
Add test for arm32 queue

### DIFF
--- a/tests/pipeline/pipeline-tests.groovy
+++ b/tests/pipeline/pipeline-tests.groovy
@@ -106,6 +106,14 @@ stage ('Run Tests') {
                 }
             },
 
+            "simpleNode - arm32" : {
+                timeout (60) {
+                    simpleNode('ubuntu.1404.arm32.open') {
+                        checkoutRepo()
+                    }
+                }
+            },
+
             "simpleNode - Explicit expression" : {
                 timeout (60) {
                     simpleNode('osx-10.12 || OSX.1012.Amd64.Open') {


### PR DESCRIPTION
Should exercise the speed at which we can create nodes.  We have been bitten in the past by a race between node creation in Jenkins and Helix work item completion.