### PR TITLE
Add dotnet-apiport/service branch for build

### DIFF
--- a/data/repolist.txt
+++ b/data/repolist.txt
@@ -197,6 +197,7 @@ Microsoft/ChakraCore branch=builtins server=dotnet-ci2
 Microsoft/ConcordExtensibilitySamples branch=master server=dotnet-ci
 Microsoft/dotnet-apiport branch=master server=dotnet-ci2
 Microsoft/dotnet-apiport branch=dev server=dotnet-ci2
+Microsoft/dotnet-apiport branch=service server=dotnet-ci2
 Microsoft/dotnet-framework-docker branch=master server=dotnet-ci
 Microsoft/dotnet-framework-docker branch=dev server=dotnet-ci
 Microsoft/MIEngine branch=master server=dotnet-ci


### PR DESCRIPTION
Adding dotnet-apiport/service branch for dotnet-bot to build because we are doing new dev work on that branch.