### PR TITLE
Make initial work item lookup catch messages a little more descriptive

### DIFF
--- a/vars/waitForHelixRuns.groovy
+++ b/vars/waitForHelixRuns.groovy
@@ -59,8 +59,8 @@ def call (def helixRunsBlob, String prStatusPrefix) {
                     mcUrlMap[helixRunKeys[correlationId]] = mcResultsUrl
                 }
                 catch (Exception ex) {
+                    println("Failed obtain Helix work item information:");
                     println(ex.toString());
-                    println(ex.getMessage().toString());
                     println(ex.getStackTrace().toString());
                     return false
                 }


### PR DESCRIPTION
Most of the time the message is empty and it looks like a NPE to the user.