### PR TITLE
Add source-build dev/release/2.1.0-preview2-fsharp branch

### DIFF
--- a/data/repolist.txt
+++ b/data/repolist.txt
@@ -149,6 +149,7 @@ dotnet/source-build branch=release/2.0 server=dotnet-ci
 dotnet/source-build branch=release/2.1.0-preview2 server=dotnet-ci
 dotnet/source-build branch=dev/release/2.0 server=dotnet-ci
 dotnet/source-build branch=dev/release/2.1 server=dotnet-ci
+dotnet/source-build branch=dev/release/2.1.0-preview2-fsharp server=dotnet-ci
 dotnet/sdk branch=master server=dotnet-ci
 dotnet/sdk branch=rel/1.0.0 server=dotnet-ci
 dotnet/sdk branch=rel/1.1.0 server=dotnet-ci


### PR DESCRIPTION
https://github.com/dotnet/source-build/blob/dev/release/2.1.0-preview2-fsharp/netci.groovy

This `dev/release/2.1.0-preview2-fsharp` branch is a fork from `release/2.1.0-preview2` made to work on an F# fix with the ability to run full CI. We'll be adding commits to `release/2.1.0-preview2` that work around the issue.