### PR TITLE
enable CI on fsharp/dev16.0

### DIFF
--- a/data/repolist.txt
+++ b/data/repolist.txt
@@ -224,6 +224,7 @@ Microsoft/visualfsharp branch=master server=dotnet-ci2
 Microsoft/visualfsharp branch=dev15.6 server=dotnet-ci2
 Microsoft/visualfsharp branch=dev15.7 server=dotnet-ci2
 Microsoft/visualfsharp branch=dev15.8 server=dotnet-ci2
+Microsoft/visualfsharp branch=dev16.0 server=dotnet-ci2
 Microsoft/PartsUnlimited branch=master server=dotnet-ci
 dotnet/templating branch=stabilize server=dotnet-ci
 dotnet/templating branch=master server=dotnet-ci


### PR DESCRIPTION
Microsoft/visualfsharp just added a `dev16.0` branch to track future work.

@mmitche for review.