### PR TITLE
remove F# branches that have been converted to VSTS CI

### DIFF
--- a/data/repolist.txt
+++ b/data/repolist.txt
@@ -242,12 +242,8 @@ Microsoft/TypeScript branch=master server=dotnet-ci2
 Microsoft/xunit-performance branch=master server=dotnet-ci
 Microsoft/xunit-performance branch=citest server=dotnet-ci
 Microsoft/Vipr branch=master server=dotnet-ci
-Microsoft/visualfsharp branch=master server=dotnet-ci2
-Microsoft/visualfsharp branch=dev15.6 server=dotnet-ci2
 Microsoft/visualfsharp branch=dev15.7 server=dotnet-ci2
 Microsoft/visualfsharp branch=dev15.8 server=dotnet-ci2
-Microsoft/visualfsharp branch=dev15.9 server=dotnet-ci2
-Microsoft/visualfsharp branch=dev16.0 server=dotnet-ci2
 Microsoft/PartsUnlimited branch=master server=dotnet-ci
 dotnet/templating branch=stabilize server=dotnet-ci
 dotnet/templating branch=master server=dotnet-ci


### PR DESCRIPTION
`master`, `dev15.9`, and `dev16.0` have been converted to VSTS CI.

`dev15.6` is no longer a branch and is not being serviced.

`dev15.7` is active for potential servicing fixes and `dev15.8` is active for preview builds so those are being left on Jenkins.

@mmitche for review/merge.