### PR TITLE
remove roslyn-tools from jenkins

### DIFF
--- a/data/repolist.txt
+++ b/data/repolist.txt
@@ -164,7 +164,6 @@ dotnet/roslyn branch=features/razorFar server=dotnet-ci
 dotnet/roslyn-analyzers branch=master server=dotnet-ci
 dotnet/roslyn-analyzers branch=dev15.3 server=dotnet-ci
 dotnet/roslyn-analyzers branch=features/dataflow server=dotnet-ci
-dotnet/roslyn-tools branch=master server=dotnet-ci
 dotnet/project-system branch=master server=dotnet-ci
 dotnet/project-system branch=dev15.0.x server=dotnet-ci
 dotnet/project-system branch=dev15.8.x server=dotnet-ci


### PR DESCRIPTION
PR validation has been moved to [Azure DevOps](https://dev.azure.com/dnceng/public/_build?definitionId=216).