### PR TITLE
Remove source-build release/2.1: moved to AzDO

### DIFF
--- a/data/repolist.txt
+++ b/data/repolist.txt
@@ -149,7 +149,6 @@ dotnet/roslyn-analyzers branch=master server=dotnet-ci
 dotnet/roslyn-analyzers branch=dev15.3 server=dotnet-ci
 dotnet/roslyn-analyzers branch=features/dataflow server=dotnet-ci
 dotnet/source-build branch=master server=dotnet-ci
-dotnet/source-build branch=release/2.1 server=dotnet-ci
 dotnet/source-build branch=release/2.2 server=dotnet-ci
 dotnet/sdk branch=experimental-classic-projects server=dotnet-ci
 dotnet/sdk branch=rel/1.0.0 server=dotnet-ci


### PR DESCRIPTION
It'll take a little more time to get full AzDO coverage on source-build `release/2.2` and `master` as well.