### PR TITLE
Remove aspnet/EntityFrameworkCore master branch

### DIFF
--- a/data/repolist.txt
+++ b/data/repolist.txt
@@ -264,7 +264,6 @@ dotnet/dotnet-ci branch=master definitionScript=tests/dsl/*.groovy isDSLTest=tru
 aspnet/aspnet-docker branch=dev server=dotnet-ci3 definitionScript=build-pipeline/pipelinejobs.groovy
 aspnet/aspnet-docker branch=master server=dotnet-ci3 definitionScript=build-pipeline/pipelinejobs.groovy
 aspnet/CORS branch=release/2.1 server=dotnet-ci3 definitionScript=build/buildpipeline/pipeline.groovy
-aspnet/EntityFrameworkCore branch=master server=dotnet-ci3 definitionScript=build/buildpipeline/pipeline.groovy
 aspnet/EntityFrameworkCore branch=release/2.1 server=dotnet-ci3 definitionScript=build/buildpipeline/pipeline.groovy
 aspnet/EntityFrameworkCore branch=release/2.2 server=dotnet-ci3 definitionScript=build/buildpipeline/pipeline.groovy
 aspnet/IISIntegration branch=master server=dotnet-ci3 definitionScript=build/buildpipeline/pipeline.groovy


### PR DESCRIPTION
Part of aspnet/EntityFrameworkCore#14053

(Keeping 2.1.x and 2.2.x branches for now since we haven't migrated them yet.)

cc @mmitche @dagood @ajcvickers