### PR TITLE
Remove corefx ci entries for branches that don't use Jenkins CI

### DIFF
--- a/data/repolist.txt
+++ b/data/repolist.txt
@@ -65,16 +65,11 @@ dotnet/coreclr branch=release/2.1 server=dotnet-ci
 dotnet/coreclr branch=release/2.1 server=dotnet-ci3 definitionScript=buildpipeline/pipelinejobs.groovy
 dotnet/coreclr branch=release/2.2 server=dotnet-ci
 dotnet/coreclr branch=release/2.2 server=dotnet-ci3 definitionScript=buildpipeline/pipelinejobs.groovy
-dotnet/corefx branch=feature/utf8string server=dotnet-ci
-dotnet/corefx branch=feature/utf8string server=dotnet-ci3 definitionScript=buildpipeline/pipelinejobs.groovy
-dotnet/corefx branch=master server=dotnet-ci
 dotnet/corefx branch=release/1.0.0 server=dotnet-ci
 dotnet/corefx branch=release/1.1.0 server=dotnet-ci
 dotnet/corefx branch=release/uwp6.0 server=dotnet-ci
 dotnet/corefx branch=release/uwp6.1 server=dotnet-ci
 dotnet/corefx branch=release/uwp6.2 server=dotnet-ci
-dotnet/corefx branch=master server=dotnet-ci2 definitionScript=perf.groovy subFolder=perf
-dotnet/corefx branch=master server=dotnet-ci3 definitionScript=buildpipeline/pipelinejobs.groovy
 dotnet/corefx branch=release/uwp6.0 server=dotnet-ci3 definitionScript=buildpipeline/pipelinejobs.groovy
 dotnet/corefx branch=release/uwp6.1 server=dotnet-ci3 definitionScript=buildpipeline/pipelinejobs.groovy
 dotnet/corefx branch=release/uwp6.2 server=dotnet-ci3 definitionScript=buildpipeline/pipelinejobs.groovy


### PR DESCRIPTION
feature/utf8string doesn't exist in corefx anymore.

cc: @danmosemsft @stephentoub @mmitche 