### PR TITLE
Remove docker-tools repo from CI repo list

### DIFF
--- a/data/repolist.txt
+++ b/data/repolist.txt
@@ -81,7 +81,6 @@ dotnet/corefxlab branch=release/2.1 server=dotnet-ci
 dotnet/corert branch=master server=dotnet-ci
 dotnet/corert branch=r2r server=dotnet-ci
 dotnet/dotnet-buildtools-prereqs-docker branch=master server=dotnet-ci
-dotnet/docker-tools branch=master server=dotnet-ci
 dotnet/dotnet-docker branch=master server=dotnet-ci
 dotnet/dotnet-docker branch=nightly server=dotnet-ci
 dotnet/orleans branch=master server=dotnet-ci


### PR DESCRIPTION
We've migrated this repo to use Azure DevOps pipelines instead.