### PR TITLE
Remove metadata-tools

### DIFF
--- a/data/repolist.txt
+++ b/data/repolist.txt
@@ -68,7 +68,6 @@ dotnet/sdk branch=release/2.2.1xx server=dotnet-ci2 definitionScript=perf.groovy
 dotnet/sdk branch=release/2.2.2xx server=dotnet-ci2 definitionScript=perf.groovy subFolder=perf
 dotnet/sdk branch=release/2.2.3xx server=dotnet-ci2 definitionScript=perf.groovy subFolder=perf
 dotnet/symreader-converter branch=master server=dotnet-ci2
-dotnet/metadata-tools branch=master server=dotnet-ci2
 dotnet/symstore branch=master server=dotnet-ci
 dotnet/wcf branch=release/1.0.0 server=dotnet-ci
 dotnet/wcf branch=release/1.1.0 server=dotnet-ci


### PR DESCRIPTION
It looks like dotnet/metadata-tools is already on Azure DevOps.  @tmat , can you confirm it's ok to remove this from Jenkins?

FYI @mmitche 